### PR TITLE
Fix: Adjust mobile layout for side-by-side grid and info block

### DIFF
--- a/style.css
+++ b/style.css
@@ -112,7 +112,54 @@ main { padding: 2rem 1rem; max-width: 1300px; margin: 0 auto; }
 
 /* --- Responsive Adjustments --- */
 @media (max-width: 900px) {
-    .game-entry { flex-direction: column; align-items: center; }
+    .game-entry {
+        flex-direction: row;
+        align-items: flex-start; /* Or stretch, if that looks better */
+        gap: 1rem; /* Add a smaller gap for mobile view */
+    }
+    .art-container {
+        flex: 0 0 40%; /* Art takes 40% of the width, doesn't grow or shrink */
+        /* Ensure aspect ratio is maintained by the image's intrinsic size */
+    }
+    .info-container {
+        flex: 1 1 58%; /* Info takes the remaining space, can grow or shrink */
+        /* max-width to prevent it from becoming too wide if art-container is less than 40% */
+        max-width: calc(60% - 1rem); /* Adjust based on the gap */
+    }
+    .info-content {
+        padding: 1rem 1.5rem; /* Adjust padding for smaller screens */
+        padding-left: 0;
+        padding-right: 0;
+    }
+    /* It might also be necessary to adjust text sizes or margins within .info-container for mobile */
+    .game-logo {
+        max-width: 70%; /* Allow logo to be a bit smaller on mobile */
+        max-height: 100px; /* Adjust max height for logo */
+    }
+    .japanese-title {
+        font-size: 1.1rem; /* Slightly smaller Japanese title */
+    }
+    .kanji-title {
+        font-size: 1.1rem; /* Adjust based on actual font and space */
+    }
+    .romaji-title {
+        font-size: 0.9rem; /* Adjust based on actual font and space */
+    }
+    .release-header {
+        font-size: 1rem;
+    }
+    .release-primary {
+        font-size: 0.9rem;
+    }
+    .release-secondary {
+        font-size: 0.75rem;
+    }
+    .external-links {
+        gap: 0.75rem; /* Smaller gap for external links */
+    }
+    .external-links img {
+        height: 36px; /* Smaller icons */
+    }
 }
 
 /* Arc Navigation Styling */


### PR DESCRIPTION
Previously, on screens narrower than 900px, the game entry's grid image (.art-container) and information block (.info-container) would stack vertically.

This change modifies the CSS for `.game-entry` within the `@media (max-width: 900px)` query to use `flex-direction: row` and `align-items: flex-start`.

The `.art-container` is now set to `flex: 0 0 40%` and `.info-container` to `flex: 1 1 58%` (with a `max-width` to account for a small gap), allowing them to sit side-by-side while maintaining responsiveness.

The grid image (`.game-grid-art`) will retain its aspect ratio due to `width: 100%` and `height: auto`, and its container's flex properties. The info block's height will adjust to its content.

Additional minor adjustments to padding, font sizes, and image sizes within the info block were also made to improve the overall mobile presentation.