### PR TITLE
Fix: Update footer with logo attributions

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,8 @@
     <footer>
         <p>
             Unofficial fan project. Not affiliated with Falcom or NIS America.<br>
-            All visual assets © Nihon Falcom Corporation / NIS America, Inc.
+            All visual assets © Nihon Falcom Corporation / NIS America, Inc.<br>
+            Wikipedia, Kiseki Wiki (Fandom), and Steam logos are trademarks of their respective owners.
         </p>
     </footer>
 


### PR DESCRIPTION
Added attributions for Wikipedia, Kiseki Wiki (Fandom), and Steam logos in site footer.