### PR TITLE
Update footer to include XSEED

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
 
     <footer>
         <p>
-            Unofficial fan project. Not affiliated with Falcom or NIS America.<br>
-            All visual assets © Nihon Falcom Corporation / NIS America, Inc.<br>
+            Unofficial fan project. Not affiliated with Falcom, NIS America, or XSEED Games.<br>
+            All visual assets © Nihon Falcom Corporation / NIS America, Inc. / XSEED Games.<br>
             Wikipedia, Kiseki Wiki (Fandom), and Steam logos are trademarks of their respective owners.
         </p>
     </footer>


### PR DESCRIPTION
The footer in index.html was modified to mention XSEED Games alongside Falcom and NIS America. This ensures proper attribution to all involved parties.