### PR TITLE
Update site text and titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>The Trails Series Compendium</title>
+    <title>Trails Visual Guide</title>
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/script.js
+++ b/script.js
@@ -171,7 +171,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ]
         },
         {
-            arc: "Epilogue Arc",
+            arc: "Reverie",
             englishTitle: "Trails into Reverie",
             japaneseTitleKanji: "英雄伝説 創の軌跡",
             japaneseTitleRomaji: "Hajimari no Kiseki",


### PR DESCRIPTION
I've replaced "Epilogue Arc" with "Reverie" in `script.js`. I also changed the site title in `index.html` from "The Trails Series Compendium" to "Trails Visual Guide".