### PR TITLE
Fix: Add spacing between game version slides

### DIFF
--- a/script.js
+++ b/script.js
@@ -238,7 +238,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (currentIndex >= itemsCount) currentIndex = itemsCount - 1;
 
                 sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
-                contentStrip.style.transform = `translateX(-${currentIndex * 100}%)`;
+                // Adjust translateX to account for the gap.
+                // Each item is 100% width, plus a 2rem gap.
+                contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
 
                 const prevButton = sliderDisplayAreaElement.querySelector('.slider-arrow-prev');
                 const nextButton = sliderDisplayAreaElement.querySelector('.slider-arrow-next');

--- a/style.css
+++ b/style.css
@@ -211,6 +211,7 @@ main {
 .slider-content-strip {
     display: flex;
     transition: transform 0.5s ease-in-out;
+    gap: 2rem; /* Added gap between slider items */
     /* Width will be dynamically handled by the number of items,
        e.g., if 2 items, it's effectively 200% of the .game-entry-slider width.
        Each .slider-item will be 100% of .game-entry-slider width. */


### PR DESCRIPTION
Previously, game version slides in the slider component were flush against each other. This caused the outgoing slide's info box to appear visually attached to the incoming slide's grid art during the transition.

This commit introduces a 2rem gap between slides using the 'gap' property on the flex container '.slider-content-strip'.

The JavaScript `navigateSlider` function has been updated to adjust the `translateX` calculation to account for this new gap, ensuring that slides are still correctly framed after the transition. The new calculation is `calc(-currentIndex * (100% + 2rem))`.