### PR TITLE
feat: Implement responsive mobile layout for visual guide

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,53 +1,27 @@
 document.addEventListener('DOMContentLoaded', () => {
-    fetch('games.json')
-        .then(response => {
-            console.log("Fetched games.json, attempting to parse response...");
-            if (!response.ok) {
-                console.error("Fetch response was not ok:", response.status, response.statusText);
-                return response.text().then(text => { throw new Error("Server error: " + response.status + " " + response.statusText + " - " + text); });
-            }
-            return response.json();
-        })
-        .then(games => {
-            console.log("Successfully parsed game data. Number of games:", games.length);
-            if (games.length > 0) {
-                console.log("First game entry sample:", games[0]);
-            }
-            const timelineContainer = document.getElementById('game-timeline-container');
-            console.log("Timeline container element:", timelineContainer);
-            if (!timelineContainer) {
-                console.error("CRITICAL: timelineContainer is null or undefined!");
-            }
-            let lastArc = null;
+    // --- Global Helper Functions ---
+    const createReleaseString = (releases) => {
+        if (!releases || releases.length === 0) {
+            return '';
+        }
+        const [firstRelease, ...remainingReleases] = releases;
+        const primaryReleaseHtml = `<span class="release-primary">${firstRelease.date} ${firstRelease.platforms}</span>`;
+        const secondaryReleasesHtml = remainingReleases.map(release =>
+            `<span class="release-secondary">, ${release.date} ${release.platforms}</span>`
+        ).join('');
+        return `${primaryReleaseHtml}${secondaryReleasesHtml}`;
+    };
 
-            // Helper function to generate the hierarchical release string (moved outside the loop and refactored for readability)
-            const createReleaseString = (releases) => {
-                if (!releases || releases.length === 0) {
-                    return '';
-                }
-
-                const [firstRelease, ...remainingReleases] = releases;
-
-                const primaryReleaseHtml = `<span class="release-primary">${firstRelease.date} ${firstRelease.platforms}</span>`;
-
-                const secondaryReleasesHtml = remainingReleases.map(release =>
-                    `<span class="release-secondary">, ${release.date} ${release.platforms}</span>`
-                ).join('');
-
-                return `${primaryReleaseHtml}${secondaryReleasesHtml}`;
-            };
-
-            // --- Helper functions for creating HTML structure ---
-            function createArtContainerHTML(game) {
-                return `
-            <div class="art-container">
+    // --- Desktop HTML Generation ---
+    function createDesktopArtContainerHTML(game) {
+        return `
+            <div class="art-container desktop-only">
                 <img src="grid/${game.assetName}.jpg" alt="${game.englishTitle} Grid Art" class="game-grid-art">
-            </div>
-        `;
-            }
+            </div>`;
+    }
 
-            function createMainInfoHTML(game) {
-                return `
+    function createDesktopMainInfoHTML(game) {
+        return `
             <div class="main-info">
                 <img src="logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="game-logo">
                 <p class="japanese-title">
@@ -64,12 +38,11 @@ document.addEventListener('DOMContentLoaded', () => {
                         <div class="release-list">${createReleaseString(game.releasesEN)}</div>
                     </div>
                 </div>
-            </div>
-        `;
-            }
+            </div>`;
+    }
 
-            function createExternalLinksHTML(game) {
-                return `
+    function createDesktopExternalLinksHTML(game) {
+        return `
             <div class="external-links">
                 <a href="${game.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
                     <img src="logo/steam.png" alt="Steam Logo">
@@ -80,66 +53,202 @@ document.addEventListener('DOMContentLoaded', () => {
                 <a href="${game.fandomUrl}" target="_blank" rel="noopener noreferrer" title="Kiseki Fandom Wiki">
                     <img src="logo/fandom.png" alt="Fandom Logo">
                 </a>
-            </div>
-        `;
-            }
+            </div>`;
+    }
 
-            function createInfoContainerHTML(game) {
-                return `
-            <div class="info-container">
+    function createDesktopInfoContainerHTML(game) {
+        return `
+            <div class="info-container desktop-only">
                 <div class="hero-background" style="background-image: url('hero/${game.assetName}.jpg');"></div>
                 <div class="info-content">
-                    ${createMainInfoHTML(game)}
-                    ${createExternalLinksHTML(game)}
+                    ${createDesktopMainInfoHTML(game)}
+                    ${createDesktopExternalLinksHTML(game)}
                 </div>
-            </div>
-        `;
-            }
+            </div>`;
+    }
 
-            function createGameEntryHTML(game) {
-                return `
-            ${createArtContainerHTML(game)}
-            ${createInfoContainerHTML(game)}
-        `;
-            }
+    function createGameEntryDesktopHTML(game) {
+        return `
+            ${createDesktopArtContainerHTML(game)}
+            ${createDesktopInfoContainerHTML(game)}`;
+    }
 
-            // Create and add Arc navigation
+    // --- Mobile HTML Generation ---
+    function createMobileCardHTML(game, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
+        const heroImageUrl = `hero/${game.assetName}.jpg`;
+        let pagerDotsHTML = '';
+
+        // Pager dots are only added to the main game card that has variants
+        if (!isVariant && game.variants && game.variants.length > 0) {
+            pagerDotsHTML += '<span class="dot active"></span>'; // First dot for the main game
+            game.variants.forEach(() => pagerDotsHTML += '<span class="dot"></span>');
+        }
+
+        // Store all variants data on the main game's mobile card for swipe updates.
+        // Also store the main game's asset name for context if needed.
+        const variantsAttr = (allVariantsData && !isVariant)
+            ? `data-variants='${JSON.stringify(allVariantsData)}' data-current-variant-index="0"`
+            : '';
+        const mainGameAttr = (mainGameAssetName && isVariant) ? `data-main-game-asset="${mainGameAssetName}"` : '';
+
+
+        return `
+            <div class="game-entry-mobile-card mobile-only" ${variantsAttr} ${mainGameAttr} data-asset-name="${game.assetName}">
+                <div class="mobile-hero-banner" data-hero-src="${heroImageUrl}">
+                    <img src="${heroImageUrl}" alt="${game.englishTitle} Hero Image">
+                </div>
+                <div class="mobile-main-info">
+                    <img src="logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="mobile-logo">
+                    <p class="japanese-title">
+                        <span class="kanji-title">${game.japaneseTitleKanji}</span>
+                        <span class="romaji-title">${game.japaneseTitleRomaji}</span>
+                    </p>
+                </div>
+                <div class="mobile-release-accordion">
+                    <div class="accordion-bar">
+                        <span>Release Details</span>
+                        <span class="chevron">▼</span>
+                    </div>
+                    <div class="accordion-content" style="display: none;">
+                        <div class="release-region">
+                            <h4 class="release-header">Japanese Release</h4>
+                            <div class="release-list">${createReleaseString(game.releasesJP)}</div>
+                        </div>
+                        <div class="release-region">
+                            <h4 class="release-header">English Release</h4>
+                            <div class="release-list">${createReleaseString(game.releasesEN)}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="mobile-external-links">
+                    <a href="${game.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
+                        <img src="logo/steam.png" alt="Steam Logo">
+                    </a>
+                    <a href="${game.wikiUrl}" target="_blank" rel="noopener noreferrer" title="Wikipedia">
+                        <img src="logo/wikipedia.png" alt="Wikipedia Logo">
+                    </a>
+                    <a href="${game.fandomUrl}" target="_blank" rel="noopener noreferrer" title="Kiseki Fandom Wiki">
+                        <img src="logo/fandom.png" alt="Fandom Logo">
+                    </a>
+                </div>
+                ${pagerDotsHTML ? `<div class="mobile-pager-dots">${pagerDotsHTML}</div>` : ''}
+            </div>`;
+    }
+
+    // Combined function for a single game object (main or variant)
+    function createFullGameRenderHTML(gameData, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
+        // For variants, allVariantsData would be the full list [mainGame, variant1, variant2...]
+        // and mainGameAssetName would be the assetName of the original game.
+        return `
+            ${createGameEntryDesktopHTML(gameData)}
+            ${createMobileCardHTML(gameData, isVariant, allVariantsData, mainGameAssetName)}
+        `;
+    }
+
+    // --- Lightbox Setup ---
+    function setupLightbox() {
+        if (document.getElementById('mobile-lightbox')) return; // Already created
+
+        const lightboxHTML = `
+            <div id="mobile-lightbox" class="mobile-lightbox-overlay" style="display:none;">
+                <span class="mobile-lightbox-close">&times;</span>
+                <img id="mobile-lightbox-image" src="" alt="Full screen hero image">
+            </div>`;
+        document.body.insertAdjacentHTML('beforeend', lightboxHTML);
+
+        const lightbox = document.getElementById('mobile-lightbox');
+        const lightboxImage = document.getElementById('mobile-lightbox-image');
+        const lightboxClose = lightbox.querySelector('.mobile-lightbox-close');
+
+        if (!lightbox || !lightboxImage || !lightboxClose) {
+            console.error("Lightbox elements not found after creation.");
+            return;
+        }
+
+        // Event delegation for hero banners, as they are dynamically added
+        document.body.addEventListener('click', function(event) {
+            const banner = event.target.closest('.mobile-hero-banner');
+            if (banner && banner.parentElement.classList.contains('mobile-only')) { // Ensure it's for the mobile card
+                const heroSrc = banner.dataset.heroSrc;
+                if (heroSrc) {
+                    lightboxImage.src = heroSrc;
+                    lightbox.style.display = 'flex';
+                }
+            }
+        });
+
+        lightboxClose.addEventListener('click', () => {
+            lightbox.style.display = 'none';
+            lightboxImage.src = '';
+        });
+        lightbox.addEventListener('click', (e) => {
+            if (e.target === lightbox) {
+                lightbox.style.display = 'none';
+                lightboxImage.src = '';
+            }
+        });
+    }
+
+    // --- Accordion Setup ---
+    function setupAccordions() {
+        // Event delegation for accordions
+        document.body.addEventListener('click', function(event) {
+            const bar = event.target.closest('.accordion-bar');
+            if (bar && bar.parentElement.closest('.mobile-only')) { // Ensure it's for the mobile card
+                const content = bar.nextElementSibling;
+                const chevron = bar.querySelector('.chevron');
+                if (content && content.classList.contains('accordion-content')) {
+                    const isExpanded = content.style.display === 'block';
+                    content.style.display = isExpanded ? 'none' : 'block';
+                    if (chevron) {
+                        chevron.classList.toggle('expanded', !isExpanded);
+                        chevron.textContent = isExpanded ? '▼' : '▲';
+                    }
+                }
+            }
+        });
+    }
+
+    fetch('games.json')
+        .then(response => {
+            if (!response.ok) {
+                console.error("Fetch response was not ok:", response.status, response.statusText);
+                return response.text().then(text => { throw new Error("Server error: " + response.status + " " + response.statusText + " - " + text); });
+            }
+            return response.json();
+        })
+        .then(games => {
+            const timelineContainer = document.getElementById('game-timeline-container');
+            if (!timelineContainer) {
+                console.error("CRITICAL: timelineContainer is null or undefined!");
+                return;
+            }
+            let lastArc = null;
+
+            // Create Arc navigation
             const headerElement = document.querySelector('header');
             if (headerElement) {
                 const uniqueArcs = [...new Set(games.map(game => game.arc))];
                 const arcNav = document.createElement('nav');
                 arcNav.className = 'arc-navigation';
-
                 uniqueArcs.forEach(arc => {
                     const link = document.createElement('a');
                     link.textContent = arc;
                     link.href = '#' + arc.toLowerCase().replace(/\s+/g, '-') + '-header';
                     arcNav.appendChild(link);
-
                     if (uniqueArcs.indexOf(arc) < uniqueArcs.length - 1) {
-                        const separator = document.createTextNode(' • ');
-                        arcNav.appendChild(separator);
+                        arcNav.appendChild(document.createTextNode(' • '));
                     }
                 });
                 headerElement.appendChild(arcNav);
-
-                // --- Smooth Scroll for Arc Navigation Links ---
-                const arcNavLinks = arcNav.querySelectorAll('a');
-                arcNavLinks.forEach(link => {
+                arcNav.querySelectorAll('a').forEach(link => {
                     link.addEventListener('click', function(event) {
                         event.preventDefault();
-                        const href = this.getAttribute('href');
-                        const targetElement = document.querySelector(href);
-
-                        if (targetElement && headerElement) {
+                        const targetElement = document.querySelector(this.getAttribute('href'));
+                        if (targetElement) {
                             const headerHeight = headerElement.offsetHeight;
-                            const additionalMargin = 10; // Small visual margin
-                            const targetPosition = targetElement.offsetTop - headerHeight - additionalMargin;
-
-                            window.scrollTo({
-                                top: targetPosition,
-                                behavior: 'smooth'
-                            });
+                            const targetPosition = targetElement.offsetTop - headerHeight - 10;
+                            window.scrollTo({ top: targetPosition, behavior: 'smooth' });
                         }
                     });
                 });
@@ -155,196 +264,281 @@ document.addEventListener('DOMContentLoaded', () => {
                     lastArc = game.arc;
                 }
 
-                let gameWrapperElement; // This will be the element added to timelineContainer
+                let gameWrapperElement;
 
                 if (game.variants && game.variants.length > 0) {
-                    // New outer wrapper for slider and arrows
                     const sliderDisplayArea = document.createElement('div');
                     sliderDisplayArea.className = 'slider-display-area';
-                    sliderDisplayArea.setAttribute('data-current-index', '0'); // Keep index here for navigateSlider
+                    sliderDisplayArea.setAttribute('data-current-index', '0');
 
-                    // Inner container for the sliding content, this will have overflow:hidden
                     const gameEntrySlider = document.createElement('div');
                     gameEntrySlider.className = 'game-entry-slider';
-                    // data-current-index might be more logical on sliderDisplayArea if arrows are direct children of it.
-                    // Let's assume navigateSlider will be passed sliderDisplayArea.
 
                     const sliderContentStrip = document.createElement('div');
                     sliderContentStrip.className = 'slider-content-strip';
 
-                    // Create and add the original game entry
+                    // Original game item
                     const originalGameItem = document.createElement('div');
                     originalGameItem.className = 'slider-item';
                     const originalGameEntry = document.createElement('div');
                     originalGameEntry.className = 'game-entry';
-                    originalGameEntry.innerHTML = createGameEntryHTML(game);
+                    // For the main game in a slider, pass its full variant data for the mobile card
+                    const allVariantDataForMobile = [game, ...game.variants];
+                    originalGameEntry.innerHTML = createFullGameRenderHTML(game, false, allVariantDataForMobile);
                     originalGameItem.appendChild(originalGameEntry);
                     sliderContentStrip.appendChild(originalGameItem);
 
-                    // Create and add variant game entries
+                    // Variant game items
                     game.variants.forEach(variant => {
                         const variantGameItem = document.createElement('div');
                         variantGameItem.className = 'slider-item';
                         const variantGameEntry = document.createElement('div');
                         variantGameEntry.className = 'game-entry';
-                        variantGameEntry.innerHTML = createGameEntryHTML(variant);
+                        // For variants in a slider, their mobile card is generated as a variant,
+                        // but it doesn't need to host the full variant data itself or pager dots.
+                        variantGameEntry.innerHTML = createFullGameRenderHTML(variant, true, null, game.assetName);
                         variantGameItem.appendChild(variantGameEntry);
                         sliderContentStrip.appendChild(variantGameItem);
                     });
 
-                    gameEntrySlider.appendChild(sliderContentStrip); // Add strip to the overflow-hidden container
-                    sliderDisplayArea.appendChild(gameEntrySlider); // Add overflow-hidden container to the display area
+                    gameEntrySlider.appendChild(sliderContentStrip);
+                    sliderDisplayArea.appendChild(gameEntrySlider);
 
-                    // Add Navigation Arrows to sliderDisplayArea (so they are not clipped)
                     const prevButton = document.createElement('button');
                     prevButton.className = 'slider-arrow slider-arrow-prev';
                     prevButton.innerHTML = '&#10094;';
-                    prevButton.setAttribute('aria-label', 'Previous version');
-                    prevButton.onclick = () => navigateSlider(sliderDisplayArea, -1); // Pass sliderDisplayArea
+                    prevButton.onclick = () => navigateSlider(sliderDisplayArea, -1);
                     sliderDisplayArea.appendChild(prevButton);
 
                     const nextButton = document.createElement('button');
                     nextButton.className = 'slider-arrow slider-arrow-next';
                     nextButton.innerHTML = '&#10095;';
-                    nextButton.setAttribute('aria-label', 'Next version');
-                    nextButton.onclick = () => navigateSlider(sliderDisplayArea, 1); // Pass sliderDisplayArea
+                    nextButton.onclick = () => navigateSlider(sliderDisplayArea, 1);
                     sliderDisplayArea.appendChild(nextButton);
 
                     gameWrapperElement = sliderDisplayArea;
-
                 } else {
-                    // Non-slider game entries
                     const standardEntry = document.createElement('div');
                     standardEntry.className = 'game-entry';
-                    standardEntry.innerHTML = createGameEntryHTML(game);
+                    standardEntry.innerHTML = createFullGameRenderHTML(game); // No variants, so no allVariantData needed for mobile here
                     gameWrapperElement = standardEntry;
                 }
-
                 timelineContainer.appendChild(gameWrapperElement);
             });
 
-            function navigateSlider(sliderDisplayAreaElement, direction) {
-                // sliderDisplayAreaElement is the new '.slider-display-area'
-                // The content strip is inside '.game-entry-slider' which is inside 'sliderDisplayAreaElement'
-                const contentStrip = sliderDisplayAreaElement.querySelector('.game-entry-slider .slider-content-strip');
-                if (!contentStrip) return;
-
-                const itemsCount = contentStrip.children.length;
-                let currentIndex = parseInt(sliderDisplayAreaElement.getAttribute('data-current-index'), 10);
-
-                currentIndex += direction;
-
-                if (currentIndex < 0) currentIndex = 0;
-                if (currentIndex >= itemsCount) currentIndex = itemsCount - 1;
-
-                sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
-                // Adjust translateX to account for the gap.
-                // Each item is 100% width, plus a 2rem gap.
-                contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
-
-                const prevButton = sliderDisplayAreaElement.querySelector('.slider-arrow-prev');
-                const nextButton = sliderDisplayAreaElement.querySelector('.slider-arrow-next');
-                if (prevButton) prevButton.disabled = currentIndex === 0;
-                if (nextButton) nextButton.disabled = currentIndex === itemsCount - 1;
-            }
-
-            // Initialize slider arrow states after all game entries are added
-            // Query for the new outer wrapper '.slider-display-area'
+            // Initialize slider arrow states
             document.querySelectorAll('.slider-display-area').forEach(sliderArea => {
-                const initialIndex = parseInt(sliderArea.getAttribute('data-current-index'), 10) || 0;
-                const contentStrip = sliderArea.querySelector('.game-entry-slider .slider-content-strip');
-                if (contentStrip) {
-                    const itemsCount = contentStrip.children.length;
-                    const prevButton = sliderArea.querySelector('.slider-arrow-prev');
-                    const nextButton = sliderArea.querySelector('.slider-arrow-next');
-                    if (prevButton) prevButton.disabled = initialIndex === 0;
-                    if (nextButton) nextButton.disabled = initialIndex >= itemsCount - 1;
-                }
+                navigateSlider(sliderArea, 0); // Initial call to set button states
             });
 
-            // --- Arc Navigation Active State Highlighting ---
+            // Setup interactive elements for mobile cards
+            setupLightbox();
+            setupAccordions();
+
+            // Arc Navigation Active State Highlighting
             const navLinks = document.querySelectorAll('.arc-navigation a');
             const arcHeaders = document.querySelectorAll('.arc-header');
-            const headerHeightThreshold = 300; // Adjust as needed, roughly header height + a bit
+            const headerHeightThreshold = headerElement ? headerElement.offsetHeight + 20 : 100;
 
             function updateActiveLink() {
                 let currentActiveArcId = null;
-
-                // First pass: find which arc is currently "active"
-                // Iterate backwards to find the *last* header that is above the threshold
                 for (let i = arcHeaders.length - 1; i >= 0; i--) {
                     const header = arcHeaders[i];
                     const rect = header.getBoundingClientRect();
                     if (rect.top <= headerHeightThreshold) {
                         currentActiveArcId = header.id;
-                        break; // Found the topmost visible arc header
+                        break;
                     }
                 }
-                
-                // If no header is above threshold (e.g. scrolled to very top, before first arc header)
-                // default to the first arc, or handle as preferred.
-                // For now, if nothing is "active" based on threshold, the first link will be made active if scrolled to top.
-                // Or, if scrolled way down past the last header, the last one remains active.
-                if (!currentActiveArcId && arcHeaders.length > 0 && window.scrollY < arcHeaders[0].offsetTop) {
-                     // If scrolled to the very top, before the first section, make the first link active.
-                    currentActiveArcId = arcHeaders[0].id;
+                if (!currentActiveArcId && arcHeaders.length > 0 && window.scrollY < arcHeaders[0].offsetTop - headerHeightThreshold) {
+                     currentActiveArcId = arcHeaders[0].id;
                 }
-
-
                 navLinks.forEach(link => {
-                    // The link's href is like "#arc-name-header"
-                    // The header's id is "arc-name-header"
-                    const linkHrefId = link.getAttribute('href').substring(1);
-                    if (linkHrefId === currentActiveArcId) {
-                        link.classList.add('active');
-                    } else {
-                        link.classList.remove('active');
-                    }
+                    link.classList.toggle('active', link.getAttribute('href').substring(1) === currentActiveArcId);
                 });
             }
-
             if (navLinks.length > 0 && arcHeaders.length > 0) {
-                window.addEventListener('scroll', updateActiveLink);
-                updateActiveLink(); // Initial call to set active link on page load
+                window.addEventListener('scroll', updateActiveLink, { passive: true });
+                updateActiveLink();
             }
+
+            // Setup swipe functionality after all cards are in the DOM
+            setupMobileVariantSwipes();
         })
         .catch(error => {
             console.error('CRITICAL ERROR fetching or processing game data:', error);
-            // Optionally, display a user-friendly message on the page
-            // const body = document.querySelector('body');
-            // if (body) {
-            //     body.innerHTML = '<h1>Error loading game data</h1><p>Sorry, the game data could not be loaded. Please try again later.</p><p>Error details: ' + error.message + '</p>';
-            // }
+            const timelineContainer = document.getElementById('game-timeline-container');
+            if (timelineContainer) {
+                timelineContainer.innerHTML = `<p style="color:red; text-align:center;">Error loading game data. Please check console.</p>`;
+            }
         });
 
-    // Back to Top Button Functionality
-    const backToTopButton = document.getElementById("backToTopBtn");
-
-    if (backToTopButton && typeof backToTopButton.addEventListener === 'function') {
-        if (typeof window !== 'undefined' && window.onscroll !== undefined) {
-            window.onscroll = function() {
-                scrollFunction();
-            };
+    // --- Mobile Variant Swipe Functionality ---
+    function updateMobileCardContent(cardElement, gameData) {
+        // Update hero banner
+        const heroBanner = cardElement.querySelector('.mobile-hero-banner');
+        const heroImg = heroBanner ? heroBanner.querySelector('img') : null;
+        if (heroBanner && heroImg) {
+            const newHeroSrc = `hero/${gameData.assetName}.jpg`;
+            heroBanner.dataset.heroSrc = newHeroSrc;
+            heroImg.src = newHeroSrc;
+            heroImg.alt = `${gameData.englishTitle} Hero Image`;
         }
 
-        function scrollFunction() {
-            const currentScrollTop = (typeof document !== 'undefined' && document.body && typeof document.body.scrollTop === 'number' ? document.body.scrollTop : 0) ||
-                                   (typeof document !== 'undefined' && document.documentElement && typeof document.documentElement.scrollTop === 'number' ? document.documentElement.scrollTop : 0);
+        // Update logo
+        const logoImg = cardElement.querySelector('.mobile-main-info .mobile-logo');
+        if (logoImg) {
+            logoImg.src = `logo/${gameData.assetName}.png`;
+            logoImg.alt = `${gameData.englishTitle} Logo`;
+        }
 
-            if (backToTopButton.style) {
-                if (currentScrollTop > 100) {
-                    backToTopButton.style.display = "block";
-                } else {
-                    backToTopButton.style.display = "none";
+        // Update titles
+        const kanjiTitleEl = cardElement.querySelector('.mobile-main-info .kanji-title');
+        if (kanjiTitleEl) kanjiTitleEl.textContent = gameData.japaneseTitleKanji;
+        const romajiTitleEl = cardElement.querySelector('.mobile-main-info .romaji-title');
+        if (romajiTitleEl) romajiTitleEl.textContent = gameData.japaneseTitleRomaji;
+
+        // Update release details
+        const releaseAccordionContent = cardElement.querySelector('.mobile-release-accordion .accordion-content');
+        if (releaseAccordionContent) {
+            const jpReleaseList = releaseAccordionContent.querySelector('.release-region:nth-child(1) .release-list');
+            if (jpReleaseList) jpReleaseList.innerHTML = createReleaseString(gameData.releasesJP);
+
+            const enReleaseList = releaseAccordionContent.querySelector('.release-region:nth-child(2) .release-list');
+            if (enReleaseList) enReleaseList.innerHTML = createReleaseString(gameData.releasesEN);
+        }
+
+        // Update external links
+        const externalLinksContainer = cardElement.querySelector('.mobile-external-links');
+        if (externalLinksContainer) {
+            const steamLink = externalLinksContainer.querySelector('a[title*="Steam"]');
+            if (steamLink) steamLink.href = gameData.steamUrl;
+            const wikiLink = externalLinksContainer.querySelector('a[title*="Wikipedia"]');
+            if (wikiLink) wikiLink.href = gameData.wikiUrl;
+            const fandomLink = externalLinksContainer.querySelector('a[title*="Fandom"]');
+            if (fandomLink) fandomLink.href = gameData.fandomUrl;
+        }
+
+        // Update the card's own asset name for consistency if needed, though not strictly used by display after this.
+        cardElement.dataset.assetName = gameData.assetName;
+    }
+
+    function setupMobileVariantSwipes() {
+        document.querySelectorAll('.game-entry-mobile-card[data-variants]').forEach(card => {
+            let touchStartX = 0;
+            let touchEndX = 0;
+            let isSwiping = false;
+            const swipeThreshold = 50; // Minimum pixels to be considered a swipe
+
+            card.addEventListener('touchstart', (event) => {
+                // Only react to single touch
+                if (event.touches.length === 1) {
+                    touchStartX = event.touches[0].clientX;
+                    isSwiping = true; // Assume swipe might start
                 }
-            }
-        }
+            }, { passive: true });
 
-        backToTopButton.addEventListener("click", function() {
-            if(typeof window !== 'undefined' && typeof window.scrollTo === 'function') {
-                window.scrollTo({top: 0, behavior: 'smooth'});
-            }
+            card.addEventListener('touchmove', (event) => {
+                if (event.touches.length === 1 && isSwiping) {
+                    touchEndX = event.touches[0].clientX;
+                    // Optional: Add visual feedback during swipe if desired (e.g., slight card movement)
+                    // To prevent vertical scroll while swiping horizontally:
+                    // Check if horizontal movement is more significant than vertical
+                    // For simplicity, we'll handle this at touchend. If more complex behavior is needed,
+                    // event.preventDefault() could be used here conditionally.
+                }
+            }, { passive: true }); // passive:true if not preventing scroll, false if you might.
+
+            card.addEventListener('touchend', () => {
+                if (!isSwiping || touchEndX === 0) { // Ensure touchmove happened
+                    isSwiping = false;
+                    touchEndX = 0; // Reset for next potential swipe
+                    return;
+                }
+
+                const deltaX = touchEndX - touchStartX;
+                let direction = 0;
+
+                if (Math.abs(deltaX) > swipeThreshold) {
+                    if (deltaX < 0) { // Swipe Left (next)
+                        direction = 1;
+                    } else { // Swipe Right (previous)
+                        direction = -1;
+                    }
+                }
+
+                if (direction !== 0) {
+                    const variantsJson = card.dataset.variants;
+                    const currentVariantIndexStr = card.dataset.currentVariantIndex;
+
+                    if (variantsJson && currentVariantIndexStr) {
+                        try {
+                            const variants = JSON.parse(variantsJson);
+                            let currentVariantIndex = parseInt(currentVariantIndexStr, 10);
+                            const totalVariants = variants.length;
+
+                            currentVariantIndex += direction;
+
+                            // Clamp index
+                            if (currentVariantIndex < 0) currentVariantIndex = 0;
+                            if (currentVariantIndex >= totalVariants) currentVariantIndex = totalVariants - 1;
+
+                            if (currentVariantIndex !== parseInt(currentVariantIndexStr, 10)) {
+                                // Update card content
+                                updateMobileCardContent(card, variants[currentVariantIndex]);
+                                card.dataset.currentVariantIndex = currentVariantIndex.toString();
+
+                                // Update pager dots
+                                const pagerDotsContainer = card.querySelector('.mobile-pager-dots');
+                                if (pagerDotsContainer) {
+                                    const dots = pagerDotsContainer.querySelectorAll('.dot');
+                                    dots.forEach((dot, idx) => {
+                                        dot.classList.toggle('active', idx === currentVariantIndex);
+                                    });
+                                }
+                            }
+                        } catch (e) {
+                            console.error("Error processing variants for swipe:", e);
+                        }
+                    }
+                }
+                // Reset for next swipe
+                isSwiping = false;
+                touchStartX = 0;
+                touchEndX = 0;
+            });
         });
     }
 
+    function navigateSlider(sliderDisplayAreaElement, direction) {
+        const contentStrip = sliderDisplayAreaElement.querySelector('.game-entry-slider .slider-content-strip');
+        if (!contentStrip) return;
+
+        const itemsCount = contentStrip.children.length;
+        let currentIndex = parseInt(sliderDisplayAreaElement.getAttribute('data-current-index'), 10);
+        currentIndex += direction;
+        currentIndex = Math.max(0, Math.min(currentIndex, itemsCount - 1));
+        sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
+        contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
+
+        const prevButton = sliderDisplayAreaElement.querySelector('.slider-arrow-prev');
+        const nextButton = sliderDisplayAreaElement.querySelector('.slider-arrow-next');
+        if (prevButton) prevButton.disabled = currentIndex === 0;
+        if (nextButton) nextButton.disabled = currentIndex === itemsCount - 1;
+    }
+
+    // Back to Top Button
+    const backToTopButton = document.getElementById("backToTopBtn");
+    if (backToTopButton) {
+        window.onscroll = function() {
+            if (document.body.scrollTop > 100 || document.documentElement.scrollTop > 100) {
+                backToTopButton.style.display = "block";
+            } else {
+                backToTopButton.style.display = "none";
+            }
+        };
+        backToTopButton.addEventListener("click", () => {
+            window.scrollTo({top: 0, behavior: 'smooth'});
+        });
+    }
 });

--- a/style.css
+++ b/style.css
@@ -266,3 +266,263 @@ main {
        Its width will be constrained by .slider-item's 100% width. */
     margin-bottom: 0; /* Remove bottom margin if game-entry usually has one, to prevent double spacing if slider itself has margin */
 }
+
+/* --- Initial Hiding of Mobile/Desktop Specific Elements --- */
+/* Mobile elements are hidden by default, shown in media query */
+.mobile-only {
+    display: none;
+}
+/* Desktop elements are shown by default, hidden in media query - .desktop-only class added via JS */
+
+
+/* --- Mobile Layout Styles (max-width: 900px) --- */
+@media (max-width: 900px) {
+    main {
+        min-width: 0; /* Override desktop min-width */
+        padding: 1rem 0.5rem; /* Reduce padding for smaller screens */
+    }
+
+    header h1 { font-size: var(--font-size-xxxl); } /* Slightly smaller header */
+
+    .desktop-only {
+        display: none !important; /* Hide desktop-specific sections */
+    }
+
+    .mobile-only {
+        display: block; /* Show mobile-specific sections */
+    }
+
+    /* If .game-entry itself is used as a flex container for desktop,
+       we might need to reset its display for mobile if mobile cards are direct children.
+       However, the JS creates .game-entry which contains .desktop-only and .mobile-only children.
+       So, .game-entry can retain its display:flex from desktop, it won't harm if children control visibility.
+       If game-entry has specific padding/margin for desktop two-column, that might need adjustment.
+       For now, assuming .game-entry is mostly a wrapper.
+    */
+
+    #game-timeline-container {
+        gap: 1.5rem; /* Reduce gap between cards */
+    }
+
+    /* Game Entry Card Styling */
+    .game-entry-mobile-card {
+        display: flex;
+        flex-direction: column;
+        background-color: #2f2f3e; /* Slightly different card background */
+        border-radius: 12px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+        overflow: hidden;
+        margin-bottom: 1.5rem; /* Spacing between cards */
+        border: 1px solid rgba(233, 213, 161, 0.2); /* Subtle gold border */
+    }
+
+    /* 1. Cinematic Hero Banner */
+    .mobile-hero-banner {
+        width: 100%;
+        height: 160px; /* Adjust height as needed */
+        overflow: hidden;
+        cursor: pointer;
+        position: relative; /* For potential overlay effects if needed */
+    }
+    .mobile-hero-banner img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover; /* Cover ensures the image fills the banner, might crop */
+        object-position: center; /* Center the image within the banner */
+        transition: transform 0.3s ease-out;
+    }
+    .mobile-hero-banner:hover img {
+        transform: scale(1.05);
+    }
+
+    /* Lightbox Styling */
+    .mobile-lightbox-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0,0,0,0.9);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 2000; /* Ensure it's on top of everything */
+        padding: 10px;
+        box-sizing: border-box;
+    }
+    #mobile-lightbox-image {
+        max-width: 95%;
+        max-height: 90%;
+        object-fit: contain;
+        border-radius: 4px;
+        box-shadow: 0 0 25px rgba(233, 213, 161, 0.3);
+    }
+    .mobile-lightbox-close {
+        position: absolute;
+        top: 15px;
+        right: 25px;
+        font-size: 2.5rem; /* Larger close button */
+        color: var(--accent-gold);
+        cursor: pointer;
+        line-height: 1;
+        transition: color 0.2s ease;
+    }
+    .mobile-lightbox-close:hover {
+        color: #fff;
+    }
+
+    /* 2. Main Info Block */
+    .mobile-main-info {
+        padding: 1rem 1rem 0.5rem 1rem; /* Reduced bottom padding */
+        text-align: center;
+        background-color: rgba(0,0,0,0.1); /* Subtle background distinction */
+    }
+    .mobile-main-info .mobile-logo { /* Specific selector for mobile logo */
+        max-width: 180px; /* Slightly larger logo */
+        height: auto;
+        max-height: 70px; /* Max height for logo */
+        margin-bottom: 0.75rem;
+        filter: drop-shadow(1px 1px 3px rgba(0,0,0,0.5));
+    }
+    .mobile-main-info .japanese-title { /* Styles for titles within mobile view */
+        margin-top: 0;
+        margin-bottom: 0.5rem; /* Space after titles */
+    }
+    .mobile-main-info .kanji-title {
+        font-size: var(--font-size-md);
+        color: var(--accent-gold);
+    }
+    .mobile-main-info .romaji-title {
+        font-size: var(--font-size-sm);
+        opacity: 0.85;
+    }
+
+    /* 3. Collapsible "Release Details" Section */
+    .mobile-release-accordion {
+        /* border-top: 1px solid rgba(233, 213, 161, 0.15); */ /* Separator line */
+    }
+    .mobile-release-accordion .accordion-bar {
+        background: rgba(255, 255, 255, 0.03); /* Subtle background for bar */
+        padding: 0.9rem 1rem;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-top: 1px solid rgba(233, 213, 161, 0.1);
+        border-bottom: 1px solid rgba(233, 213, 161, 0.1);
+        transition: background-color 0.2s ease;
+    }
+    .mobile-release-accordion .accordion-bar:hover {
+        background: rgba(255, 255, 255, 0.06);
+    }
+    .mobile-release-accordion .accordion-bar span:first-child { /* "Release Details" text */
+        font-weight: 500;
+        font-size: var(--font-size-base);
+        color: var(--text-primary);
+    }
+    .mobile-release-accordion .chevron {
+        font-size: var(--font-size-sm);
+        color: var(--accent-gold);
+        transition: transform 0.3s ease;
+    }
+    .mobile-release-accordion .chevron.expanded { /* JS will toggle this class */
+        transform: rotate(180deg);
+    }
+    .mobile-release-accordion .accordion-content {
+        padding: 1rem;
+        background-color: rgba(0,0,0,0.15); /* Slightly darker for content area */
+        border-bottom: 1px solid rgba(233, 213, 161, 0.1);
+        /* display: none; is handled by JS */
+    }
+    .mobile-release-accordion .accordion-content .release-region {
+        margin-bottom: 0.75rem;
+    }
+    .mobile-release-accordion .accordion-content .release-region:last-child {
+        margin-bottom: 0;
+    }
+    .mobile-release-accordion .accordion-content .release-header {
+        font-size: var(--font-size-sm); /* Smaller header in accordion */
+        color: var(--accent-gold);
+        margin-bottom: 0.25rem;
+    }
+    .mobile-release-accordion .accordion-content .release-list {
+        font-size: var(--font-size-xs); /* Smaller text in accordion */
+        line-height: var(--line-height-normal);
+    }
+    .mobile-release-accordion .accordion-content .release-primary {
+        font-weight: normal;
+    }
+    .mobile-release-accordion .accordion-content .release-secondary {
+        opacity: 0.8;
+    }
+
+
+    /* 4. External Links Action Bar */
+    .mobile-external-links {
+        display: flex;
+        justify-content: space-around; /* Evenly space icons */
+        align-items: center;
+        padding: 0.75rem 1rem 1rem 1rem; /* Top, LR, Bottom */
+        background-color: rgba(0,0,0,0.1); /* Match main info bg */
+        border-top: 1px solid rgba(233, 213, 161, 0.1);
+    }
+    .mobile-external-links a img {
+        width: 32px; /* Icon size */
+        height: 32px;
+        opacity: 0.7;
+        transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    .mobile-external-links a:hover img {
+        opacity: 1;
+        transform: scale(1.1);
+    }
+
+    /* Mobile "Variants" Slider - Pager Dots */
+    .mobile-pager-dots {
+        text-align: center;
+        padding: 0.75rem 0; /* Space around dots */
+        background-color: rgba(0,0,0,0.1); /* Match main info bg */
+    }
+    .mobile-pager-dots .dot {
+        display: inline-block;
+        width: 10px;   /* Larger dots */
+        height: 10px;
+        background-color: var(--text-secondary); /* Inactive dot color */
+        border-radius: 50%;
+        margin: 0 5px; /* Spacing between dots */
+        transition: background-color 0.3s ease, transform 0.3s ease;
+        cursor: pointer; /* If we make dots clickable later */
+    }
+    .mobile-pager-dots .dot.active {
+        background-color: var(--accent-gold); /* Active dot color */
+        transform: scale(1.2);
+    }
+
+    /* Slider specific adjustments for mobile if any are needed */
+    /* The desktop slider arrows (.slider-arrow) should be hidden as they are part of .desktop-only */
+    .slider-display-area {
+        /* On mobile, the slider-display-area itself might not need special styles if its
+           .game-entry child (which contains the mobile card) is what's being swiped.
+           If the whole slider-display-area becomes the swipe target, then styles might go here.
+           For now, assuming swipe happens on .game-entry-mobile-card. */
+    }
+    .game-entry-slider {
+        /* This is the overflow:hidden container for desktop.
+           On mobile, if we are not using this for swipe, its role might change or it might be hidden.
+           For now, assuming it's hidden via its parent .desktop-only elements or direct children.
+           If .slider-item > .game-entry > .game-entry-mobile-card is the structure,
+           then .game-entry-slider itself would be part of the .desktop-only structure.
+        */
+    }
+
+    /* Ensure that .game-entry that contains .game-entry-mobile-card doesn't add extra padding/margin on mobile */
+    .game-entry {
+        padding: 0; /* Reset any padding if it was for desktop layout */
+        margin: 0;  /* Reset any margin if it was for desktop layout */
+        /* background: transparent; /* Ensure it doesn't have its own background conflicting with card */
+        /* display: block; /* Reset flex if it was specific to desktop two-column */
+        /* The JS structure is .game-entry > .game-entry-mobile-card and .game-entry > .desktop-stuff */
+        /* So .game-entry itself doesn't need much styling for mobile, it's just a container. */
+    }
+
+}


### PR DESCRIPTION
Implemented a fully custom, responsive mobile layout for the Trails Visual Guide, activating at a breakpoint of 900px or narrower.

Key features for mobile:
- Replaces desktop view with a single-column stack of interactive cards.
- Each game entry transformed into a card with:
  - Cinematic hero banner: Tappable to open a full-screen lightbox.
  - Main info block: Game logo and titles.
  - Collapsible "Release Details" section: Accordion behavior with chevron animation.
  - External links action bar: Evenly spaced icons.
- For games with variants:
  - Touch-native horizontal swipe gesture to switch between main game and variants.
  - Pager dots below the card indicate variant count and active variant.
- Desktop layout remains unchanged on screens wider than 900px.
- Existing desktop .art-container is hidden on mobile.