### PR TITLE
fix: Correctly hide desktop slider components on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,5 @@
         </p>
     </footer>
 
-    <button id="backToTopBtn" title="Go to top">Top</button>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -74,62 +74,70 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Mobile HTML Generation ---
-    function createMobileCardHTML(game, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
-        const heroImageUrl = `hero/${game.assetName}.jpg`;
-        let pagerDotsHTML = '';
 
-        // Pager dots are only added to the main game card that has variants
+    // New function to generate only the inner content of a mobile card
+    function generateMobileCardInnerContentHTML(gameData) {
+        const heroImageUrl = `hero/${gameData.assetName}.jpg`;
+        return `
+            <div class="mobile-hero-banner" data-hero-src="${heroImageUrl}">
+                <img src="${heroImageUrl}" alt="${gameData.englishTitle} Hero Image">
+            </div>
+            <div class="mobile-main-info">
+                <img src="logo/${gameData.assetName}.png" alt="${gameData.englishTitle} Logo" class="mobile-logo">
+                <p class="japanese-title">
+                    <span class="kanji-title">${gameData.japaneseTitleKanji}</span>
+                    <span class="romaji-title">${gameData.japaneseTitleRomaji}</span>
+                </p>
+            </div>
+            <div class="mobile-release-accordion">
+                <div class="accordion-bar">
+                    <span>Release Details</span>
+                    <span class="chevron">▼</span>
+                </div>
+                <div class="accordion-content" style="display: none;">
+                    <div class="release-region">
+                        <h4 class="release-header">Japanese Release</h4>
+                        <div class="release-list">${createReleaseString(gameData.releasesJP)}</div>
+                    </div>
+                    <div class="release-region">
+                        <h4 class="release-header">English Release</h4>
+                        <div class="release-list">${createReleaseString(gameData.releasesEN)}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="mobile-external-links">
+                <a href="${gameData.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
+                    <img src="logo/steam.png" alt="Steam Logo">
+                </a>
+                <a href="${gameData.wikiUrl}" target="_blank" rel="noopener noreferrer" title="Wikipedia">
+                    <img src="logo/wikipedia.png" alt="Wikipedia Logo">
+                </a>
+                <a href="${gameData.fandomUrl}" target="_blank" rel="noopener noreferrer" title="Kiseki Fandom Wiki">
+                    <img src="logo/fandom.png" alt="Fandom Logo">
+                </a>
+            </div>
+        `;
+    }
+
+    function createMobileCardHTML(game, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
+        let pagerDotsHTML = '';
         if (!isVariant && game.variants && game.variants.length > 0) {
             pagerDotsHTML += '<span class="dot active"></span>'; // First dot for the main game
             game.variants.forEach(() => pagerDotsHTML += '<span class="dot"></span>');
         }
 
-        // Store all variants data on the main game's mobile card for swipe updates.
-        // Also store the main game's asset name for context if needed.
         const variantsAttr = (allVariantsData && !isVariant)
             ? `data-variants='${JSON.stringify(allVariantsData)}' data-current-variant-index="0"`
             : '';
         const mainGameAttr = (mainGameAssetName && isVariant) ? `data-main-game-asset="${mainGameAssetName}"` : '';
 
+        // Initial content for the first wrapper
+        const initialContentHTML = generateMobileCardInnerContentHTML(game);
 
         return `
             <div class="game-entry-mobile-card mobile-only" ${variantsAttr} ${mainGameAttr} data-asset-name="${game.assetName}">
-                <div class="mobile-hero-banner" data-hero-src="${heroImageUrl}">
-                    <img src="${heroImageUrl}" alt="${game.englishTitle} Hero Image">
-                </div>
-                <div class="mobile-main-info">
-                    <img src="logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="mobile-logo">
-                    <p class="japanese-title">
-                        <span class="kanji-title">${game.japaneseTitleKanji}</span>
-                        <span class="romaji-title">${game.japaneseTitleRomaji}</span>
-                    </p>
-                </div>
-                <div class="mobile-release-accordion">
-                    <div class="accordion-bar">
-                        <span>Release Details</span>
-                        <span class="chevron">▼</span>
-                    </div>
-                    <div class="accordion-content" style="display: none;">
-                        <div class="release-region">
-                            <h4 class="release-header">Japanese Release</h4>
-                            <div class="release-list">${createReleaseString(game.releasesJP)}</div>
-                        </div>
-                        <div class="release-region">
-                            <h4 class="release-header">English Release</h4>
-                            <div class="release-list">${createReleaseString(game.releasesEN)}</div>
-                        </div>
-                    </div>
-                </div>
-                <div class="mobile-external-links">
-                    <a href="${game.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
-                        <img src="logo/steam.png" alt="Steam Logo">
-                    </a>
-                    <a href="${game.wikiUrl}" target="_blank" rel="noopener noreferrer" title="Wikipedia">
-                        <img src="logo/wikipedia.png" alt="Wikipedia Logo">
-                    </a>
-                    <a href="${game.fandomUrl}" target="_blank" rel="noopener noreferrer" title="Kiseki Fandom Wiki">
-                        <img src="logo/fandom.png" alt="Fandom Logo">
-                    </a>
+                <div class="mobile-card-content-wrapper">
+                    ${initialContentHTML}
                 </div>
                 ${pagerDotsHTML ? `<div class="mobile-pager-dots">${pagerDotsHTML}</div>` : ''}
             </div>`;
@@ -374,139 +382,178 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
     // --- Mobile Variant Swipe Functionality ---
-    function updateMobileCardContent(cardElement, gameData) {
-        // Update hero banner
-        const heroBanner = cardElement.querySelector('.mobile-hero-banner');
-        const heroImg = heroBanner ? heroBanner.querySelector('img') : null;
-        if (heroBanner && heroImg) {
-            const newHeroSrc = `hero/${gameData.assetName}.jpg`;
-            heroBanner.dataset.heroSrc = newHeroSrc;
-            heroImg.src = newHeroSrc;
-            heroImg.alt = `${gameData.englishTitle} Hero Image`;
+    // The old `updateMobileCardContent` function was here and has been removed as it's no longer used.
+
+    function animateVariantChange(card, newVariantData, direction) { // direction: 1 for next (slides left), -1 for prev (slides right)
+        const currentContentWrapper = card.querySelector('.mobile-card-content-wrapper');
+        if (!currentContentWrapper) {
+            console.error("Current content wrapper not found for animation.");
+            // Fallback to simple update if structure is wrong (should not happen)
+            // This could happen if the initial card structure was not created with a wrapper.
+            // However, createMobileCardHTML ensures a wrapper exists.
+            // For robustness, we could recreate the card's content if no wrapper is found.
+            const shell = card.querySelector('.mobile-pager-dots') ? card.querySelector('.mobile-pager-dots').cloneNode(true) : null;
+            card.innerHTML = ''; // Clear card
+            const newInitialContentWrapper = document.createElement('div');
+            newInitialContentWrapper.className = 'mobile-card-content-wrapper';
+            newInitialContentWrapper.innerHTML = generateMobileCardInnerContentHTML(newVariantData);
+            card.appendChild(newInitialContentWrapper);
+            if (shell) card.appendChild(shell); // Re-append dots if they existed
+            console.warn("Fallback: Recreated card content due to missing wrapper for animation.");
+            return;
         }
 
-        // Update logo
-        const logoImg = cardElement.querySelector('.mobile-main-info .mobile-logo');
-        if (logoImg) {
-            logoImg.src = `logo/${gameData.assetName}.png`;
-            logoImg.alt = `${gameData.englishTitle} Logo`;
+        const newContentWrapper = document.createElement('div');
+        newContentWrapper.className = 'mobile-card-content-wrapper';
+        newContentWrapper.innerHTML = generateMobileCardInnerContentHTML(newVariantData);
+
+        // Set initial position for the new content
+        if (direction === 1) { // Sliding to next (new content from right)
+            newContentWrapper.classList.add('prepare-slide-from-right');
+        } else { // Sliding to previous (new content from left)
+            newContentWrapper.classList.add('prepare-slide-from-left');
         }
+        card.appendChild(newContentWrapper);
 
-        // Update titles
-        const kanjiTitleEl = cardElement.querySelector('.mobile-main-info .kanji-title');
-        if (kanjiTitleEl) kanjiTitleEl.textContent = gameData.japaneseTitleKanji;
-        const romajiTitleEl = cardElement.querySelector('.mobile-main-info .romaji-title');
-        if (romajiTitleEl) romajiTitleEl.textContent = gameData.japaneseTitleRomaji;
+        // Force reflow to ensure initial position is applied before transition starts
+        // Reading offsetHeight is a common trick for this.
+        void newContentWrapper.offsetHeight;
 
-        // Update release details
-        const releaseAccordionContent = cardElement.querySelector('.mobile-release-accordion .accordion-content');
-        if (releaseAccordionContent) {
-            const jpReleaseList = releaseAccordionContent.querySelector('.release-region:nth-child(1) .release-list');
-            if (jpReleaseList) jpReleaseList.innerHTML = createReleaseString(gameData.releasesJP);
+        // Start animation
+        requestAnimationFrame(() => {
+            if (direction === 1) {
+                currentContentWrapper.classList.add('slide-out-to-left');
+                newContentWrapper.classList.remove('prepare-slide-from-right');
+            } else {
+                currentContentWrapper.classList.add('slide-out-to-right');
+                newContentWrapper.classList.remove('prepare-slide-from-left');
+            }
+            newContentWrapper.classList.add('slide-in'); // Common class for sliding to translateX(0)
+        });
 
-            const enReleaseList = releaseAccordionContent.querySelector('.release-region:nth-child(2) .release-list');
-            if (enReleaseList) enReleaseList.innerHTML = createReleaseString(gameData.releasesEN);
+        newContentWrapper.addEventListener('transitionend', function handler(event) {
+            // Ensure we're reacting to the transform transition on the new wrapper itself
+            if (event.propertyName !== 'transform' || event.target !== newContentWrapper) {
+                return;
+            }
+
+            if (currentContentWrapper && currentContentWrapper.parentNode === card) {
+                 card.removeChild(currentContentWrapper);
+            }
+            newContentWrapper.classList.remove('slide-in', 'prepare-slide-from-left', 'prepare-slide-from-right');
+            // No specific class needed for "active" state once it's the only one.
+
+            newContentWrapper.removeEventListener('transitionend', handler);
+        }, { once: true }); // Ensure listener is called only once
+    }
+
+
+    function changeVariant(card, targetIndex) {
+        const variantsJson = card.dataset.variants;
+        const currentVariantIndexStr = card.dataset.currentVariantIndex;
+
+        if (variantsJson && currentVariantIndexStr) {
+            try {
+                const variants = JSON.parse(variantsJson);
+                let currentVariantIndex = parseInt(currentVariantIndexStr, 10);
+                const totalVariants = variants.length;
+
+                // Ensure targetIndex is valid
+                if (targetIndex < 0 || targetIndex >= totalVariants || targetIndex === currentVariantIndex) {
+                    return; // No change needed or invalid index
+                }
+
+                const direction = targetIndex > currentVariantIndex ? 1 : -1;
+
+                animateVariantChange(card, variants[targetIndex], direction);
+                card.dataset.currentVariantIndex = targetIndex.toString();
+                card.dataset.assetName = variants[targetIndex].assetName; // Update main card asset name too
+
+                // Update pager dots
+                const pagerDotsContainer = card.querySelector('.mobile-pager-dots');
+                if (pagerDotsContainer) {
+                    const dots = pagerDotsContainer.querySelectorAll('.dot');
+                    dots.forEach((dot, idx) => {
+                        dot.classList.toggle('active', idx === targetIndex);
+                    });
+                }
+
+            } catch (e) {
+                console.error("Error processing variants for change:", e);
+            }
         }
-
-        // Update external links
-        const externalLinksContainer = cardElement.querySelector('.mobile-external-links');
-        if (externalLinksContainer) {
-            const steamLink = externalLinksContainer.querySelector('a[title*="Steam"]');
-            if (steamLink) steamLink.href = gameData.steamUrl;
-            const wikiLink = externalLinksContainer.querySelector('a[title*="Wikipedia"]');
-            if (wikiLink) wikiLink.href = gameData.wikiUrl;
-            const fandomLink = externalLinksContainer.querySelector('a[title*="Fandom"]');
-            if (fandomLink) fandomLink.href = gameData.fandomUrl;
-        }
-
-        // Update the card's own asset name for consistency if needed, though not strictly used by display after this.
-        cardElement.dataset.assetName = gameData.assetName;
     }
 
     function setupMobileVariantSwipes() {
         document.querySelectorAll('.game-entry-mobile-card[data-variants]').forEach(card => {
             let touchStartX = 0;
             let touchEndX = 0;
-            let isSwiping = false;
-            const swipeThreshold = 50; // Minimum pixels to be considered a swipe
+            let isProcessingSwipe = false; // Lock to prevent multiple triggers
+            const swipeThreshold = 50;
 
             card.addEventListener('touchstart', (event) => {
-                // Only react to single touch
-                if (event.touches.length === 1) {
-                    touchStartX = event.touches[0].clientX;
-                    isSwiping = true; // Assume swipe might start
-                }
+                if (isProcessingSwipe || event.touches.length !== 1) return;
+                touchStartX = event.touches[0].clientX;
+                touchEndX = 0; // Reset touchEndX
             }, { passive: true });
 
             card.addEventListener('touchmove', (event) => {
-                if (event.touches.length === 1 && isSwiping) {
-                    touchEndX = event.touches[0].clientX;
-                    // Optional: Add visual feedback during swipe if desired (e.g., slight card movement)
-                    // To prevent vertical scroll while swiping horizontally:
-                    // Check if horizontal movement is more significant than vertical
-                    // For simplicity, we'll handle this at touchend. If more complex behavior is needed,
-                    // event.preventDefault() could be used here conditionally.
-                }
-            }, { passive: true }); // passive:true if not preventing scroll, false if you might.
+                if (isProcessingSwipe || event.touches.length !== 1) return;
+                touchEndX = event.touches[0].clientX;
+            }, { passive: true });
 
             card.addEventListener('touchend', () => {
-                if (!isSwiping || touchEndX === 0) { // Ensure touchmove happened
-                    isSwiping = false;
-                    touchEndX = 0; // Reset for next potential swipe
+                if (isProcessingSwipe || touchEndX === 0) { // Ensure touchmove happened
+                    touchStartX = 0; // Reset for next swipe
                     return;
                 }
 
+                isProcessingSwipe = true; // Set lock
+
                 const deltaX = touchEndX - touchStartX;
-                let direction = 0;
+                let swipeDirection = 0; // 1 for next, -1 for prev
 
                 if (Math.abs(deltaX) > swipeThreshold) {
-                    if (deltaX < 0) { // Swipe Left (next)
-                        direction = 1;
-                    } else { // Swipe Right (previous)
-                        direction = -1;
+                    if (deltaX < 0) swipeDirection = 1; // Swipe Left (next)
+                    else swipeDirection = -1;          // Swipe Right (previous)
+                }
+
+                if (swipeDirection !== 0) {
+                    const currentVariantIndex = parseInt(card.dataset.currentVariantIndex, 10);
+                    const variants = JSON.parse(card.dataset.variants);
+                    const targetIndex = currentVariantIndex + swipeDirection;
+
+                    if (targetIndex >= 0 && targetIndex < variants.length) {
+                        changeVariant(card, targetIndex);
                     }
                 }
 
-                if (direction !== 0) {
-                    const variantsJson = card.dataset.variants;
-                    const currentVariantIndexStr = card.dataset.currentVariantIndex;
-
-                    if (variantsJson && currentVariantIndexStr) {
-                        try {
-                            const variants = JSON.parse(variantsJson);
-                            let currentVariantIndex = parseInt(currentVariantIndexStr, 10);
-                            const totalVariants = variants.length;
-
-                            currentVariantIndex += direction;
-
-                            // Clamp index
-                            if (currentVariantIndex < 0) currentVariantIndex = 0;
-                            if (currentVariantIndex >= totalVariants) currentVariantIndex = totalVariants - 1;
-
-                            if (currentVariantIndex !== parseInt(currentVariantIndexStr, 10)) {
-                                // Update card content
-                                updateMobileCardContent(card, variants[currentVariantIndex]);
-                                card.dataset.currentVariantIndex = currentVariantIndex.toString();
-
-                                // Update pager dots
-                                const pagerDotsContainer = card.querySelector('.mobile-pager-dots');
-                                if (pagerDotsContainer) {
-                                    const dots = pagerDotsContainer.querySelectorAll('.dot');
-                                    dots.forEach((dot, idx) => {
-                                        dot.classList.toggle('active', idx === currentVariantIndex);
-                                    });
-                                }
-                            }
-                        } catch (e) {
-                            console.error("Error processing variants for swipe:", e);
-                        }
-                    }
-                }
-                // Reset for next swipe
-                isSwiping = false;
+                // Reset for next swipe attempt after a short delay to allow animation to start/finish
+                setTimeout(() => {
+                    isProcessingSwipe = false;
+                }, 500); // Adjust delay based on transition duration
                 touchStartX = 0;
                 touchEndX = 0;
             });
+
+            // Add click listeners for pager dots on this card
+            const pagerDotsContainer = card.querySelector('.mobile-pager-dots');
+            if (pagerDotsContainer) {
+                const dots = pagerDotsContainer.querySelectorAll('.dot');
+                dots.forEach((dot, index) => {
+                    dot.addEventListener('click', () => {
+                        // Check if this dot is already active or if an animation is in progress
+                        if (dot.classList.contains('active') || isProcessingSwipe) {
+                            return;
+                        }
+                        isProcessingSwipe = true; // Set lock for dot click as well
+                        changeVariant(card, index);
+                        setTimeout(() => { // Release lock after animation
+                            isProcessingSwipe = false;
+                        }, 500);
+                    });
+                });
+            }
         });
     }
 
@@ -527,18 +574,5 @@ document.addEventListener('DOMContentLoaded', () => {
         if (nextButton) nextButton.disabled = currentIndex === itemsCount - 1;
     }
 
-    // Back to Top Button
-    const backToTopButton = document.getElementById("backToTopBtn");
-    if (backToTopButton) {
-        window.onscroll = function() {
-            if (document.body.scrollTop > 100 || document.documentElement.scrollTop > 100) {
-                backToTopButton.style.display = "block";
-            } else {
-                backToTopButton.style.display = "none";
-            }
-        };
-        backToTopButton.addEventListener("click", () => {
-            window.scrollTo({top: 0, behavior: 'smooth'});
-        });
-    }
+    // Back to Top Button logic was here. It has been removed.
 });

--- a/style.css
+++ b/style.css
@@ -167,30 +167,7 @@ main {
 .arc-navigation a.active {
     color: var(--accent-gold);
 }
-/* --- Back to Top Button --- */
-#backToTopBtn {
-  display: none; /* Hidden by default */
-  position: fixed;
-  bottom: 20px;
-  right: 30px;
-  z-index: 1001; /* Ensure it's above other elements like sticky nav */
-  border: none;
-  outline: none;
-  background-color: var(--accent-gold);
-  color: var(--primary-bg); /* Text color that contrasts with accent-gold */
-  cursor: pointer;
-  padding: 12px 15px;
-  border-radius: 4px;
-  font-size: var(--font-size-md);
-  font-weight: bold;
-  opacity: 0.8;
-  transition: background-color 0.3s, opacity 0.3s;
-}
-
-#backToTopBtn:hover {
-  background-color: #d4af37; /* A slightly darker gold or adjust as needed */
-  opacity: 1;
-}
+/* --- Back to Top Button CSS has been removed --- */
 
 /* --- Game Entry Slider Styles --- */
 .slider-display-area {
@@ -306,15 +283,57 @@ main {
 
     /* Game Entry Card Styling */
     .game-entry-mobile-card {
-        display: flex;
-        flex-direction: column;
-        background-color: #2f2f3e; /* Slightly different card background */
+        display: flex; /* This might need to be re-evaluated if children are all position:absolute */
+        /* If direct children are for layout (not animated content), flex is fine.
+           If the card itself becomes a container for swappable absolute positioned content blocks,
+           then its own display might not matter as much as its position:relative and overflow:hidden.
+           Let's assume the current flex structure builds the static parts of the card, and then
+           a specific region within it will handle the animated content.
+           Alternatively, the *entire* card's content becomes swappable.
+           The plan implies entire card content slides. So, .game-entry-mobile-card needs position:relative.
+           Its direct children (hero, main-info etc.) will be wrapped in a new sliding div.
+        */
+        flex-direction: column; /* Keep for now, might be overridden by content wrapper */
+        background-color: #2f2f3e;
         border-radius: 12px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-        overflow: hidden;
-        margin-bottom: 1.5rem; /* Spacing between cards */
-        border: 1px solid rgba(233, 213, 161, 0.2); /* Subtle gold border */
+        overflow: hidden; /* Crucial for sliding animation */
+        margin-bottom: 1.5rem;
+        border: 1px solid rgba(233, 213, 161, 0.2);
+        position: relative; /* For absolute positioning of content children */
+        min-height: 450px; /* Approximate minimum height, adjust as needed, to prevent collapse during animation */
     }
+
+    .mobile-card-content-wrapper {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%; /* This might be tricky if height is dynamic. Consider flex column for children. */
+        display: flex;
+        flex-direction: column;
+        transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94); /* Smooth transition */
+        background-color: #2f2f3e; /* Match card background to avoid flicker */
+    }
+
+    /* Animation States */
+    .mobile-card-content-wrapper.slide-out-to-left {
+        transform: translateX(-100%);
+    }
+    .mobile-card-content-wrapper.slide-out-to-right {
+        transform: translateX(100%);
+    }
+    .mobile-card-content-wrapper.slide-in { /* Target state, coming from either side */
+        transform: translateX(0%);
+    }
+    /* Initial positions before sliding in (JS will set these temporarily) */
+    .mobile-card-content-wrapper.prepare-slide-from-left {
+        transform: translateX(-100%);
+    }
+    .mobile-card-content-wrapper.prepare-slide-from-right {
+        transform: translateX(100%);
+    }
+
 
     /* 1. Cinematic Hero Banner */
     .mobile-hero-banner {
@@ -498,21 +517,30 @@ main {
         transform: scale(1.2);
     }
 
-    /* Slider specific adjustments for mobile if any are needed */
-    /* The desktop slider arrows (.slider-arrow) should be hidden as they are part of .desktop-only */
-    .slider-display-area {
-        /* On mobile, the slider-display-area itself might not need special styles if its
-           .game-entry child (which contains the mobile card) is what's being swiped.
-           If the whole slider-display-area becomes the swipe target, then styles might go here.
-           For now, assuming swipe happens on .game-entry-mobile-card. */
+    /* Slider specific adjustments for mobile */
+    .slider-display-area .slider-arrow { /* Target arrows specifically within a slider area */
+        display: none !important;
     }
-    .game-entry-slider {
-        /* This is the overflow:hidden container for desktop.
-           On mobile, if we are not using this for swipe, its role might change or it might be hidden.
-           For now, assuming it's hidden via its parent .desktop-only elements or direct children.
-           If .slider-item > .game-entry > .game-entry-mobile-card is the structure,
-           then .game-entry-slider itself would be part of the .desktop-only structure.
-        */
+
+    /* Neutralize the desktop slider mechanism for variant games on mobile */
+    .slider-display-area .game-entry-slider {
+        overflow: visible !important;
+    }
+    .slider-display-area .slider-content-strip {
+        display: block !important; /* Stack items */
+        transform: none !important; /* Remove JS-applied transform */
+        gap: 0 !important; /* Reset desktop gap */
+        width: 100% !important; /* Ensure it doesn't try to be wider */
+    }
+
+    /* Ensure only the first slider-item's content is rendered by the layout engine for mobile,
+       as the mobile card within it will handle its own variant display. */
+    .slider-display-area .slider-item {
+        width: 100% !important; /* Make item take full width if parent is block */
+        flex-basis: auto !important; /* Reset flex basis */
+    }
+    .slider-display-area .slider-item:not(:first-child) {
+        display: none !important;
     }
 
     /* Ensure that .game-entry that contains .game-entry-mobile-card doesn't add extra padding/margin on mobile */


### PR DESCRIPTION
Refined CSS rules for mobile view (<= 900px) to:
- Hide desktop slider arrows.
- Neutralize the desktop slider's horizontal layout and transform behavior.
- Ensure only the first variant item's mobile card is displayed from the desktop slider structure, allowing the mobile card's own swipe/dot navigation to function without interference.

This corrects an issue where the previous attempt to hide the entire slider area would also hide the mobile content nested within it.