### PR TITLE
feat: Update mobile hero, desktop nav, and pill width

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,16 @@
+/**
+ * @file script.js
+ * Handles dynamic game data loading, HTML generation for game entries (desktop & mobile),
+ * and interactive features like sliders, accordions, lightbox, and navigation.
+ */
 document.addEventListener('DOMContentLoaded', () => {
     // --- Global Helper Functions ---
+
+    /**
+     * Creates a formatted HTML string for release dates.
+     * @param {Array<Object>} releases - Array of release objects, each with date and platforms.
+     * @returns {string} HTML string representing the formatted release dates.
+     */
     const createReleaseString = (releases) => {
         if (!releases || releases.length === 0) {
             return '';
@@ -13,6 +24,12 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     // --- Desktop HTML Generation ---
+
+    /**
+     * Creates HTML for the desktop game art container.
+     * @param {Object} game - The game data object.
+     * @returns {string} HTML string for the art container.
+     */
     function createDesktopArtContainerHTML(game) {
         return `
             <div class="art-container desktop-only">
@@ -20,6 +37,11 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>`;
     }
 
+    /**
+     * Creates HTML for the desktop main info section (logo, titles, releases).
+     * @param {Object} game - The game data object.
+     * @returns {string} HTML string for the main info section.
+     */
     function createDesktopMainInfoHTML(game) {
         return `
             <div class="main-info">
@@ -41,6 +63,11 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>`;
     }
 
+    /**
+     * Creates HTML for the desktop external links section.
+     * @param {Object} game - The game data object.
+     * @returns {string} HTML string for the external links.
+     */
     function createDesktopExternalLinksHTML(game) {
         return `
             <div class="external-links">
@@ -56,6 +83,11 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>`;
     }
 
+    /**
+     * Creates HTML for the desktop info container (background, content).
+     * @param {Object} game - The game data object.
+     * @returns {string} HTML string for the info container.
+     */
     function createDesktopInfoContainerHTML(game) {
         return `
             <div class="info-container desktop-only">
@@ -67,6 +99,11 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>`;
     }
 
+    /**
+     * Creates the complete HTML for a desktop game entry.
+     * @param {Object} game - The game data object.
+     * @returns {string} HTML string for the desktop game entry.
+     */
     function createGameEntryDesktopHTML(game) {
         return `
             ${createDesktopArtContainerHTML(game)}
@@ -74,6 +111,15 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Mobile HTML Generation ---
+
+    /**
+     * Creates HTML for a mobile game card.
+     * @param {Object} game - The game data for the current card.
+     * @param {boolean} [isVariant=false] - Whether this card is for a variant.
+     * @param {Array<Object>|null} [allVariantsData=null] - Full list of variants (including main game) if this is the main game card.
+     * @param {string|null} [mainGameAssetName=null] - Asset name of the main game if this is a variant card.
+     * @returns {string} HTML string for the mobile game card.
+     */
     function createMobileCardHTML(game, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
         const heroImageUrl = `hero/${game.assetName}.jpg`;
         let pagerDotsHTML = '';
@@ -135,7 +181,14 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>`;
     }
 
-    // Combined function for a single game object (main or variant)
+    /**
+     * Creates the combined HTML for both desktop and mobile views of a single game or variant.
+     * @param {Object} gameData - The game data for the current item.
+     * @param {boolean} [isVariant=false] - Whether this item is a variant.
+     * @param {Array<Object>|null} [allVariantsData=null] - Full list of variants (including main) for mobile card context.
+     * @param {string|null} [mainGameAssetName=null] - Asset name of the main game for mobile variant context.
+     * @returns {string} HTML string for the complete game render.
+     */
     function createFullGameRenderHTML(gameData, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
         // For variants, allVariantsData would be the full list [mainGame, variant1, variant2...]
         // and mainGameAssetName would be the assetName of the original game.
@@ -146,6 +199,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Lightbox Setup ---
+    /**
+     * Sets up the mobile lightbox functionality.
+     * Creates lightbox DOM elements if they don't exist and attaches event listeners.
+     */
     function setupLightbox() {
         if (document.getElementById('mobile-lightbox')) return; // Already created
 
@@ -166,16 +223,18 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Event delegation for hero banners, as they are dynamically added
-        document.body.addEventListener('click', function(event) {
-            const banner = event.target.closest('.mobile-hero-banner');
-            if (banner && banner.parentElement.classList.contains('mobile-only')) { // Ensure it's for the mobile card
-                const heroSrc = banner.dataset.heroSrc;
-                if (heroSrc) {
-                    lightboxImage.src = heroSrc;
-                    lightbox.style.display = 'flex';
-                }
-            }
-        });
+        // document.body.addEventListener('click', function(event) {
+        //     const banner = event.target.closest('.mobile-hero-banner');
+        //     if (banner && banner.parentElement.classList.contains('mobile-only')) { // Ensure it's for the mobile card
+        //         const heroSrc = banner.dataset.heroSrc;
+        //         if (heroSrc) {
+        //             lightboxImage.src = heroSrc;
+        //             lightbox.style.display = 'flex';
+        //         }
+        //     }
+        // });
+        // Lightbox functionality for mobile hero images removed as per new requirements.
+        // The lightbox HTML and general close logic will remain in case it's used for other purposes later.
 
         lightboxClose.addEventListener('click', () => {
             lightbox.style.display = 'none';
@@ -190,6 +249,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- Accordion Setup ---
+    /**
+     * Sets up accordion functionality for mobile release details.
+     * Uses event delegation on the body.
+     */
     function setupAccordions() {
         // Event delegation for accordions
         document.body.addEventListener('click', function(event) {
@@ -308,13 +371,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     prevButton.className = 'slider-arrow slider-arrow-prev';
                     prevButton.innerHTML = '&#10094;';
                     prevButton.onclick = () => navigateSlider(sliderDisplayArea, -1);
-                    sliderDisplayArea.appendChild(prevButton);
+                    // sliderDisplayArea.appendChild(prevButton); // Old prev button removed
 
-                    const nextButton = document.createElement('button');
-                    nextButton.className = 'slider-arrow slider-arrow-next';
-                    nextButton.innerHTML = '&#10095;';
-                    nextButton.onclick = () => navigateSlider(sliderDisplayArea, 1);
-                    sliderDisplayArea.appendChild(nextButton);
+                    // const nextButton = document.createElement('button'); // Old next button removed
+                    // nextButton.className = 'slider-arrow slider-arrow-next';
+                    // nextButton.innerHTML = '&#10095;';
+                    // nextButton.onclick = () => navigateSlider(sliderDisplayArea, 1);
+                    // sliderDisplayArea.appendChild(nextButton);
+
+                    const navButton = document.createElement('button');
+                    navButton.className = 'slider-nav-button desktop-only'; // Added desktop-only
+                    // Icon and onclick will be set by navigateSlider
+                    sliderDisplayArea.appendChild(navButton);
+                    sliderDisplayArea.navButton = navButton; // Store reference to the button
 
                     gameWrapperElement = sliderDisplayArea;
                 } else {
@@ -374,6 +443,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
     // --- Mobile Variant Navigation Functionality (formerly Swipe) ---
+
+    /**
+     * Updates the content of a mobile game card with new game data.
+     * Used when navigating between game variants on mobile.
+     * @param {HTMLElement} cardElement - The .game-entry-mobile-card element to update.
+     * @param {Object} gameData - The game data object for the new variant.
+     */
     function updateMobileCardContent(cardElement, gameData) {
         // Update hero banner
         const heroBanner = cardElement.querySelector('.mobile-hero-banner');
@@ -423,6 +499,10 @@ document.addEventListener('DOMContentLoaded', () => {
         cardElement.dataset.assetName = gameData.assetName;
     }
 
+    /**
+     * Sets up click-based navigation for mobile game variants using pager dots.
+     * Attaches event listeners to pager dots to update card content and trigger animations.
+     */
     function setupMobileVariantNavigation() { // Renamed from setupMobileVariantSwipes
         document.querySelectorAll('.game-entry-mobile-card[data-variants]').forEach(card => {
             const pagerDotsContainer = card.querySelector('.mobile-pager-dots');
@@ -473,21 +553,47 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    /**
+     * Handles navigation for desktop sliders (previous/next game variant).
+     * @param {HTMLElement} sliderDisplayAreaElement - The .slider-display-area element.
+     * @param {number} direction - -1 for previous, 1 for next, 0 for initial setup.
+     */
     function navigateSlider(sliderDisplayAreaElement, direction) {
         const contentStrip = sliderDisplayAreaElement.querySelector('.game-entry-slider .slider-content-strip');
         if (!contentStrip) return;
 
         const itemsCount = contentStrip.children.length;
         let currentIndex = parseInt(sliderDisplayAreaElement.getAttribute('data-current-index'), 10);
-        currentIndex += direction;
-        currentIndex = Math.max(0, Math.min(currentIndex, itemsCount - 1));
-        sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
+
+        // If direction is 0, it's an initial setup call, don't change currentIndex yet.
+        if (direction !== 0) {
+            currentIndex += direction;
+            currentIndex = Math.max(0, Math.min(currentIndex, itemsCount - 1));
+            sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
+        }
+
         contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
 
-        const prevButton = sliderDisplayAreaElement.querySelector('.slider-arrow-prev');
-        const nextButton = sliderDisplayAreaElement.querySelector('.slider-arrow-next');
-        if (prevButton) prevButton.disabled = currentIndex === 0;
-        if (nextButton) nextButton.disabled = currentIndex === itemsCount - 1;
+        const navButton = sliderDisplayAreaElement.navButton; // Get stored reference
+        if (!navButton) return;
+
+        if (itemsCount <= 1) {
+            navButton.disabled = true;
+            navButton.style.display = 'none'; // Hide if only one or no items
+        } else {
+            navButton.style.display = 'flex'; // Ensure it's visible
+            navButton.disabled = false;
+
+            if (currentIndex < itemsCount - 1) {
+                // Not at the last item, so button is "Next"
+                navButton.innerHTML = '&#10095;'; // → (Next)
+                navButton.onclick = () => navigateSlider(sliderDisplayAreaElement, 1);
+            } else {
+                // At the last item, button is "Previous"
+                navButton.innerHTML = '&#10094;'; // ← (Previous)
+                navButton.onclick = () => navigateSlider(sliderDisplayAreaElement, -1);
+            }
+        }
     }
 
 });

--- a/style.css
+++ b/style.css
@@ -199,49 +199,45 @@ main {
     /* .game-entry styles will apply to the child div within .slider-item */
 }
 
-.slider-arrow {
+/* Styles for .slider-arrow, .slider-arrow-prev, .slider-arrow-next are removed. */
+/* New styles for the single desktop slider navigation button are added below. */
+
+
+/* New styles for the single desktop slider navigation button */
+.slider-nav-button {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    z-index: 10; /* Above the content strip */
-    background-color: rgba(0, 0, 0, 0.5); /* Will be adjusted later for fade out */
+    bottom: 15px;
+    right: 15px;
+    z-index: 15; /* Ensure it's above hero image, but below potential modals */
+    background-color: rgba(0, 0, 0, 0.6);
     color: var(--accent-gold);
-    border: none;
-    padding: 15px 20px; /* Increased padding */
-    font-size: var(--font-size-xxl); /* Increased font size */
+    border: 1px solid var(--accent-gold);
+    border-radius: 50%; /* Circular button */
+    width: 44px;
+    height: 44px;
+    font-size: var(--font-size-xl); /* Arrow size */
     cursor: pointer;
-    transition: background-color 0.3s ease, opacity 0.3s ease-out; /* Added opacity transition */
-    border-radius: 4px;
-    opacity: 1; /* Start fully visible */
+    transition: background-color 0.3s ease, opacity 0.3s ease-out, color 0.3s ease, border-color 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
 }
 
-.slider-arrow:hover {
+.slider-nav-button:hover {
     background-color: rgba(0, 0, 0, 0.8);
+    border-color: #fff;
 }
 
-.slider-arrow:disabled {
-    opacity: 0; /* Will fade to invisible */
+.slider-nav-button:disabled {
+    opacity: 0.4;
     cursor: not-allowed;
-    pointer-events: none; /* Make it non-interactive when invisible */
+    background-color: rgba(0, 0, 0, 0.3);
+    border-color: var(--text-secondary);
+    color: var(--text-secondary);
 }
 
-.slider-arrow-prev {
-    left: -80px; /* Increased offset for more space */
-}
-
-.slider-arrow-next {
-    right: -80px; /* Increased offset for more space */
-}
-
-/* Ensure that the .game-entry within a .slider-item behaves as expected.
-   The default .game-entry is a flex container. This should still work.
-   If .game-entry had a max-width, it would apply here correctly. */
-.slider-item .game-entry {
-    /* No specific overrides needed here unless there are conflicts.
-       The .game-entry styles should apply as is.
-       Its width will be constrained by .slider-item's 100% width. */
-    margin-bottom: 0; /* Remove bottom margin if game-entry usually has one, to prevent double spacing if slider itself has margin */
-}
+/* .slider-item .game-entry specific styling was removed as not needed */
 
 /* --- Initial Hiding of Mobile/Desktop Specific Elements --- */
 /* Mobile elements are hidden by default, shown in media query */
@@ -297,7 +293,7 @@ main {
         width: 100%;
         height: 160px; /* Adjust height as needed */
         overflow: hidden;
-        cursor: pointer;
+        /* cursor: pointer; Removed as hero is no longer clickable for lightbox */
         position: relative; /* For potential overlay effects if needed */
     }
     .mobile-hero-banner img {
@@ -453,93 +449,68 @@ main {
         transform: scale(1.1);
     }
 
-    /* Mobile "Variants" Slider - Pager Dots */
-    .mobile-pager-dots {
+    /* Mobile "Variants" Pager Pill Buttons */
+    .mobile-pager-dots { /* This div centers the pill container */
         text-align: center;
-        padding: 0.75rem 0; /* Space around the pill */
-        /* background-color: rgba(0,0,0,0.1); Removed, pill has its own bg */
-        display: flex; /* Use flex to center the pill itself if it's inline-flex */
+        padding: 0.75rem 0;
+        display: flex;
         justify-content: center;
     }
-    .mobile-pager-dots-container { /* New wrapper for the pill itself */
-        display: inline-flex; /* Makes the container only as wide as its content */
-        border-radius: 20px; /* High value for pill shape */
-        background-color: rgba(255, 255, 255, 0.05); /* Subtle background for the pill container */
+    .mobile-pager-dots-container { /* The pill container itself */
+        display: inline-flex;
+        border-radius: 20px; /* Rounded ends for the pill */
+        background-color: rgba(255, 255, 255, 0.05);
         border: 1px solid rgba(255, 255, 255, 0.15);
-        overflow: hidden; /* Ensures children conform to border-radius */
+        overflow: hidden; /* Ensures segments conform to the pill shape */
         box-shadow: 0 1px 3px rgba(0,0,0,0.1);
     }
-    .mobile-pager-dots .dot {
-        display: flex; /* To center content if we add numbers */
+    .mobile-pager-dots .dot { /* Individual segment/button within the pill */
+        display: flex;
         align-items: center;
         justify-content: center;
-        width: 20px;   /* Size of the segment's clickable area ( W/H before padding ) */
-        height: 20px;
-        padding: 4px 6px; /* Padding contributes to clickable area and visual size */
-        background-color: transparent; /* Inactive segments */
-        border: none; /* Remove individual borders */
-        border-right: 1px solid rgba(255, 255, 255, 0.15); /* Separator line */
-        /* border-radius: 0; Reset individual radius, handled by container or first/last child */
-        margin: 0; /* Remove margins for connected look */
-        transition: background-color 0.2s ease; /* Only transition background */
+        width: 36px;   /* Width of the segment - adjusted to 36px */
+        height: 20px;  /* Height of the segment */
+        padding: 4px 6px; /* Padding contributes to overall size and touch target */
+        background-color: transparent; /* Default for inactive segments */
+        border: none; /* Individual borders removed */
+        border-right: 1px solid rgba(255, 255, 255, 0.15); /* Separator line between segments */
+        margin: 0; /* No margin for a connected look */
+        transition: background-color 0.2s ease; /* Smooth transition for background changes */
         cursor: pointer;
-        color: var(--text-secondary); /* Default text color for numbers if added */
+        color: var(--text-secondary); /* Default text color (e.g., for future numbers) */
         font-size: var(--font-size-xs);
     }
     .mobile-pager-dots .dot:last-child {
-        border-right: none; /* No separator for the last item */
+        border-right: none; /* No separator for the last segment */
     }
-    .mobile-pager-dots .dot:hover { /* Hover for inactive segments */
+    .mobile-pager-dots .dot:hover { /* Hover state for inactive segments */
         background-color: rgba(255, 255, 255, 0.1);
     }
-    .mobile-pager-dots .dot.active {
+    .mobile-pager-dots .dot.active { /* Active segment */
         background-color: var(--accent-gold);
-        color: var(--primary-bg); /* For contrast if numbers are added */
-        /* transform: none; Remove previous scaling if any */
-        /* The border-right of an active segment might need to visually merge or change
-           For now, the default separator will remain. Can be refined if needed. */
+        color: var(--primary-bg); /* Text color for active segment (e.g., for future numbers) */
     }
-    /* Note: The border-radius for first-child and last-child on .dot elements
-       is not strictly necessary if the parent .mobile-pager-dots-container has overflow:hidden.
-       The parent's border-radius will clip the children.
-       If visual issues arise, they can be added:
-       .mobile-pager-dots .dot:first-child { border-top-left-radius: 20px; border-bottom-left-radius: 20px; }
-       .mobile-pager-dots .dot:last-child { border-top-right-radius: 20px; border-bottom-right-radius: 20px; }
-       However, this can be tricky if the dots themselves have borders.
-       Simpler to rely on parent's overflow:hidden.
-    */
+    /* End of Mobile "Variants" Pager Pill Buttons */
+
 
     /* Slider specific adjustments for mobile if any are needed */
-    }
-
-    /* Slider specific adjustments for mobile if any are needed */
-    /* The desktop slider arrows (.slider-arrow) should be hidden as they are part of .desktop-only */
+    /* Desktop slider arrows are hidden on mobile via .slider-arrow { display: none; } below */
     .slider-display-area {
-        /* On mobile, the slider-display-area itself might not need special styles if its
-           .game-entry child (which contains the mobile card) is what's being swiped.
-           If the whole slider-display-area becomes the swipe target, then styles might go here.
-           For now, assuming swipe happens on .game-entry-mobile-card. */
+        /* No specific mobile styles needed here for the display area itself. */
+        /* Its children control desktop/mobile visibility. */
     }
     .game-entry-slider {
-        /* This is the overflow:hidden container for desktop.
-           On mobile, if we are not using this for swipe, its role might change or it might be hidden.
-           For now, assuming it's hidden via its parent .desktop-only elements or direct children.
-           If .slider-item > .game-entry > .game-entry-mobile-card is the structure,
-           then .game-entry-slider itself would be part of the .desktop-only structure.
-        */
+        /* This is the overflow:hidden container for desktop slides. */
+        /* It's part of the .desktop-only content generated by JS. */
     }
 
-    /* Ensure that .game-entry that contains .game-entry-mobile-card doesn't add extra padding/margin on mobile */
+    /* Reset .game-entry styles when it's a container on mobile, as its children handle styling */
     .game-entry {
-        padding: 0; /* Reset any padding if it was for desktop layout */
-        margin: 0;  /* Reset any margin if it was for desktop layout */
-        /* background: transparent; /* Ensure it doesn't have its own background conflicting with card */
-        /* display: block; /* Reset flex if it was specific to desktop two-column */
-        /* The JS structure is .game-entry > .game-entry-mobile-card and .game-entry > .desktop-stuff */
-        /* So .game-entry itself doesn't need much styling for mobile, it's just a container. */
+        padding: 0;
+        margin: 0;
     }
 
-    /* Mobile Card Swipe Animations */
+    /* Mobile Card Variant Navigation Animations */
     .game-entry-mobile-card .mobile-hero-banner,
     .game-entry-mobile-card .mobile-main-info,
     .game-entry-mobile-card .mobile-release-accordion, /* Target accordion directly if content is part of it */
@@ -588,10 +559,6 @@ main {
         opacity: 1;
         transform: translateX(0);
     }
-
-
-    /* Hide desktop slider arrows on mobile */
-    .slider-arrow {
-        display: none;
-    }
+    /* Former .slider-arrow hiding rule removed as the class is no longer in use. */
+    /* The new .slider-nav-button is desktop-only via JS-added class or direct styling if needed. */
 }


### PR DESCRIPTION
- Mobile: Removed click-to-fullscreen lightbox functionality from hero images.
  - Commented out relevant event listener in script.js.
  - Removed cursor:pointer from .mobile-hero-banner CSS.

- Desktop: Refactored slider navigation to use a single dynamic button.
  - Removed old previous/next arrow buttons and their CSS.
  - Added a new single .slider-nav-button positioned in the bottom-right of the info-container.
  - JavaScript logic in navigateSlider updated to change this button's icon (Next → / Previous ←) and its click action based on the current slide's position (Next until end, then becomes Previous).
  - Button is hidden if there's only one item in the slider.

- Mobile: Increased width of pager pill segments to 36px for better usability and visual balance.