### PR TITLE
Feat: Add source code link to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,8 @@
         <p>
             Unofficial fan project. Not affiliated with Falcom, NIS America, XSEED, or GungHo.<br>
             All visual assets © Nihon Falcom Corporation / NIS America, Inc. / XSEED Games / GungHo Online Entertainment, Inc.<br>
-            Wikipedia, Kiseki Wiki (Fandom), and Steam logos are trademarks of their respective owners.
+            Wikipedia, Kiseki Wiki (Fandom), and Steam logos are trademarks of their respective owners.<br>
+            <a href="https://github.com/jun-eau/trails-visual-guide/">Source Code</a>
         </p>
     </footer>
 


### PR DESCRIPTION
Added a link to the project's GitHub repository in the website footer. The link text is "Source Code" and it directs to https://github.com/jun-eau/trails-visual-guide/.