### PR TITLE
Feat: Add PlayStation and Nintendo store links and icons

### DIFF
--- a/games.json
+++ b/games.json
@@ -8,6 +8,8 @@
         "steamUrl": "https://store.steampowered.com/app/251150/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky",
+        "playstationUrl": null,
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "June 24, 2004", "platforms": "(PC)" },
             { "date": "June 28, 2006", "platforms": "(PSP)" },
@@ -45,6 +47,8 @@
         "steamUrl": "https://store.steampowered.com/app/251290/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_SC",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_SC",
+        "playstationUrl": null,
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "March 9, 2006", "platforms": "(PC)" },
             { "date": "December 27, 2007", "platforms": "(PSP)" },
@@ -64,6 +68,8 @@
         "steamUrl": "https://store.steampowered.com/app/436670/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_the_3rd",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_the_3rd",
+        "playstationUrl": null,
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "June 28, 2007", "platforms": "(PC)" },
             { "date": "July 24, 2008", "platforms": "(PSP)" },
@@ -83,6 +89,8 @@
         "steamUrl": "https://store.steampowered.com/app/1668510/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_from_Zero",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_from_Zero",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10003242",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-from-zero-switch/",
         "releasesJP": [
             { "date": "September 30, 2010", "platforms": "(PSP)" },
             { "date": "October 18, 2012", "platforms": "(PS Vita)" },
@@ -101,6 +109,8 @@
         "steamUrl": "https://store.steampowered.com/app/1668520/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_to_Azure",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_to_Azure",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10003337",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-to-azure-switch/",
         "releasesJP": [
             { "date": "September 29, 2011", "platforms": "(PSP)" },
             { "date": "June 12, 2014", "platforms": "(PS Vita)" },
@@ -119,6 +129,8 @@
         "steamUrl": "https://store.steampowered.com/app/538680/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/231981/",
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "September 26, 2013", "platforms": "(PS3, PS Vita)" },
             { "date": "March 8, 2018", "platforms": "(PS4)" }
@@ -139,6 +151,8 @@
         "steamUrl": "https://store.steampowered.com/app/748490/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_II",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_II",
+        "playstationUrl": "https://store.playstation.com/en-us/product/UP1023-CUSA12566_00-EDSENNOKISEKI2ND",
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "September 25, 2014", "platforms": "(PS3, PS Vita)" },
             { "date": "April 26, 2018", "platforms": "(PS4)" }
@@ -159,6 +173,8 @@
         "steamUrl": "https://store.steampowered.com/app/991270/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_III",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_III",
+        "playstationUrl": "https://store.playstation.com/en-us/product/UP1063-CUSA15119_00-FULLGAME00000000",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-of-cold-steel-iii-switch/",
         "releasesJP": [
             { "date": "September 28, 2017", "platforms": "(PS4)" }
         ],
@@ -177,6 +193,8 @@
         "steamUrl": "https://store.steampowered.com/app/1198010/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_IV",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_IV",
+        "playstationUrl": "https://store.playstation.com/en-us/product/UP1063-CUSA19637_00-EDSENNOKISEKI4TH",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-of-cold-steel-iv-switch/",
         "releasesJP": [
             { "date": "September 27, 2018", "platforms": "(PS4)" }
         ],
@@ -194,6 +212,8 @@
         "steamUrl": "https://store.steampowered.com/app/1668540/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_into_Reverie",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_into_Reverie",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10003228",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-into-reverie-switch/",
         "releasesJP": [
             { "date": "August 27, 2020", "platforms": "(PS4)" },
             { "date": "August 26, 2021", "platforms": "(PC, Switch)" }
@@ -211,6 +231,8 @@
         "steamUrl": "https://store.steampowered.com/app/1811950/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_through_Daybreak",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_through_Daybreak",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10001886",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-through-daybreak-switch/",
         "releasesJP": [
             { "date": "September 30, 2021", "platforms": "(PS4)" },
             { "date": "July 28, 2022", "platforms": "(PS5)" }
@@ -228,6 +250,8 @@
         "steamUrl": "https://store.steampowered.com/app/2138610/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_Through_Daybreak_II",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_through_Daybreak_II",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10004596",
+        "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-through-daybreak-ii-switch/",
         "releasesJP": [
             { "date": "September 29, 2022", "platforms": "(PS4, PS5)" }
         ],
@@ -244,6 +268,8 @@
         "steamUrl": "https://store.steampowered.com/app/3316940/",
         "wikiUrl": "https://en.wikipedia.org/wiki/The_Legend_of_Heroes:_Trails_Beyond_the_Horizon",
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_beyond_the_Horizon",
+        "playstationUrl": "https://store.playstation.com/en-us/concept/10012789",
+        "nintendoUrl": null,
         "releasesJP": [
             { "date": "September 26, 2024", "platforms": "(PS4, PS5)" }
         ],

--- a/script.js
+++ b/script.js
@@ -74,6 +74,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 <a href="${game.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
                     <img src="logo/steam.png" alt="Steam Logo">
                 </a>
+                ${game.playstationUrl ? `
+                <a href="${game.playstationUrl}" target="_blank" rel="noopener noreferrer" title="PlayStation Store Page">
+                    <img src="logo/playstation.png" alt="PlayStation Store Logo">
+                </a>` : ''}
+                ${game.nintendoUrl ? `
+                <a href="${game.nintendoUrl}" target="_blank" rel="noopener noreferrer" title="Nintendo eShop Page">
+                    <img src="logo/nintendo.png" alt="Nintendo eShop Logo">
+                </a>` : ''}
                 <a href="${game.wikiUrl}" target="_blank" rel="noopener noreferrer" title="Wikipedia">
                     <img src="logo/wikipedia.png" alt="Wikipedia Logo">
                 </a>
@@ -170,6 +178,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     <a href="${game.steamUrl}" target="_blank" rel="noopener noreferrer" title="Steam Store Page">
                         <img src="logo/steam.png" alt="Steam Logo">
                     </a>
+                    ${game.playstationUrl ? `
+                    <a href="${game.playstationUrl}" target="_blank" rel="noopener noreferrer" title="PlayStation Store Page" class="playstation-link">
+                        <img src="logo/playstation.png" alt="PlayStation Store Logo">
+                    </a>` : ''}
+                    ${game.nintendoUrl ? `
+                    <a href="${game.nintendoUrl}" target="_blank" rel="noopener noreferrer" title="Nintendo eShop Page" class="nintendo-link">
+                        <img src="logo/nintendo.png" alt="Nintendo eShop Logo">
+                    </a>` : ''}
                     <a href="${game.wikiUrl}" target="_blank" rel="noopener noreferrer" title="Wikipedia">
                         <img src="logo/wikipedia.png" alt="Wikipedia Logo">
                     </a>
@@ -489,6 +505,56 @@ document.addEventListener('DOMContentLoaded', () => {
         if (externalLinksContainer) {
             const steamLink = externalLinksContainer.querySelector('a[title*="Steam"]');
             if (steamLink) steamLink.href = gameData.steamUrl;
+
+            // Update or create/remove PlayStation link
+            let psLink = externalLinksContainer.querySelector('.playstation-link');
+            if (gameData.playstationUrl) {
+                if (!psLink) {
+                    // Create and insert psLink if it doesn't exist
+                    psLink = document.createElement('a');
+                    psLink.className = 'playstation-link';
+                    psLink.target = '_blank';
+                    psLink.rel = 'noopener noreferrer';
+                    psLink.title = 'PlayStation Store Page';
+                    psLink.innerHTML = '<img src="logo/playstation.png" alt="PlayStation Store Logo">';
+                    // Insert after Steam, before Wikipedia
+                    const wikiLinkForInsert = externalLinksContainer.querySelector('a[title*="Wikipedia"]');
+                    externalLinksContainer.insertBefore(psLink, wikiLinkForInsert);
+                }
+                psLink.href = gameData.playstationUrl;
+                psLink.style.display = ''; // Ensure it's visible
+            } else if (psLink) {
+                psLink.remove(); // Remove if no URL and element exists
+            }
+
+            // Update or create/remove Nintendo link
+            let nintendoLink = externalLinksContainer.querySelector('.nintendo-link');
+            if (gameData.nintendoUrl) {
+                if (!nintendoLink) {
+                    // Create and insert nintendoLink if it doesn't exist
+                    nintendoLink = document.createElement('a');
+                    nintendoLink.className = 'nintendo-link';
+                    nintendoLink.target = '_blank';
+                    nintendoLink.rel = 'noopener noreferrer';
+                    nintendoLink.title = 'Nintendo eShop Page';
+                    nintendoLink.innerHTML = '<img src="logo/nintendo.png" alt="Nintendo eShop Logo">';
+                    // Insert after PlayStation (if it exists) or Steam, before Wikipedia
+                    const psLinkForInsert = externalLinksContainer.querySelector('.playstation-link');
+                    const wikiLinkForInsert = externalLinksContainer.querySelector('a[title*="Wikipedia"]');
+                    if (psLinkForInsert) {
+                        psLinkForInsert.after(nintendoLink);
+                    } else if (steamLink) {
+                        steamLink.after(nintendoLink);
+                    } else { // Fallback if somehow steam link is also missing, unlikely
+                        externalLinksContainer.insertBefore(nintendoLink, wikiLinkForInsert);
+                    }
+                }
+                nintendoLink.href = gameData.nintendoUrl;
+                nintendoLink.style.display = ''; // Ensure it's visible
+            } else if (nintendoLink) {
+                nintendoLink.remove(); // Remove if no URL and element exists
+            }
+
             const wikiLink = externalLinksContainer.querySelector('a[title*="Wikipedia"]');
             if (wikiLink) wikiLink.href = gameData.wikiUrl;
             const fandomLink = externalLinksContainer.querySelector('a[title*="Fandom"]');


### PR DESCRIPTION
- Updated games.json to include playstationUrl and nintendoUrl fields for each game.
- Modified script.js to dynamically render PlayStation and Nintendo icons and links in both desktop and mobile views.
- Ensured that links are only displayed if available for a game.
- Updated mobile variant navigation to correctly show/hide/update these links when switching between game variants.
- Verified that new icons are inserted in the correct order (Steam, PSN, Nintendo, Wikipedia, Fandom).