### PR TITLE
feat: Overhaul mobile card header

### DIFF
--- a/script.js
+++ b/script.js
@@ -146,12 +146,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const mainGameAttr = (mainGameAssetName && isVariant) ? `data-main-game-asset="${mainGameAssetName}"` : '';
 
 
+        // --mobile-hero-url will be set inline on this div for dynamic background updates
         return `
             <div class="game-entry-mobile-card mobile-only card-content-visible" ${variantsAttr} ${mainGameAttr} data-asset-name="${game.assetName}">
-                <div class="mobile-hero-banner" data-hero-src="${heroImageUrl}">
-                    <img src="${heroImageUrl}" alt="${game.englishTitle} Hero Image">
-                </div>
-                <div class="mobile-main-info">
+                <div class="mobile-unified-header" style="--mobile-hero-url: url('hero/${game.assetName}.jpg');">
                     <img src="logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="mobile-logo">
                     <p class="japanese-title">
                         <span class="kanji-title">${game.japaneseTitleKanji}</span>
@@ -467,30 +465,26 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {Object} gameData - The game data object for the new variant.
      */
     function updateMobileCardContent(cardElement, gameData) {
-        // Update hero banner
-        const heroBanner = cardElement.querySelector('.mobile-hero-banner');
-        const heroImg = heroBanner ? heroBanner.querySelector('img') : null;
-        if (heroBanner && heroImg) {
-            const newHeroSrc = `hero/${gameData.assetName}.jpg`;
-            heroBanner.dataset.heroSrc = newHeroSrc;
-            heroImg.src = newHeroSrc;
-            heroImg.alt = `${gameData.englishTitle} Hero Image`;
+        // Update unified header's background image (via CSS variable)
+        const unifiedHeader = cardElement.querySelector('.mobile-unified-header');
+        if (unifiedHeader) {
+            unifiedHeader.style.setProperty('--mobile-hero-url', `url('hero/${gameData.assetName}.jpg')`);
         }
 
-        // Update logo
-        const logoImg = cardElement.querySelector('.mobile-main-info .mobile-logo');
+        // Update logo within the unified header
+        const logoImg = cardElement.querySelector('.mobile-unified-header .mobile-logo');
         if (logoImg) {
             logoImg.src = `logo/${gameData.assetName}.png`;
             logoImg.alt = `${gameData.englishTitle} Logo`;
         }
 
-        // Update titles
-        const kanjiTitleEl = cardElement.querySelector('.mobile-main-info .kanji-title');
+        // Update titles within the unified header
+        const kanjiTitleEl = cardElement.querySelector('.mobile-unified-header .kanji-title');
         if (kanjiTitleEl) kanjiTitleEl.textContent = gameData.japaneseTitleKanji;
-        const romajiTitleEl = cardElement.querySelector('.mobile-main-info .romaji-title');
+        const romajiTitleEl = cardElement.querySelector('.mobile-unified-header .romaji-title');
         if (romajiTitleEl) romajiTitleEl.textContent = gameData.japaneseTitleRomaji;
 
-        // Update release details
+        // Update release details (no change in structure, just ensuring selectors are still valid)
         const releaseAccordionContent = cardElement.querySelector('.mobile-release-accordion .accordion-content');
         if (releaseAccordionContent) {
             const jpReleaseList = releaseAccordionContent.querySelector('.release-region:nth-child(1) .release-list');

--- a/style.css
+++ b/style.css
@@ -288,23 +288,39 @@ main {
         border: 1px solid rgba(233, 213, 161, 0.2); /* Subtle gold border */
     }
 
-    /* 1. Cinematic Hero Banner */
-    .mobile-hero-banner {
-        width: 100%;
-        height: 160px; /* Adjust height as needed */
-        overflow: hidden;
-        /* cursor: pointer; Removed as hero is no longer clickable for lightbox */
-        position: relative; /* For potential overlay effects if needed */
+    /* 1. Unified Mobile Header */
+    .mobile-unified-header {
+        position: relative; /* For pseudo-element background and content layering */
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        height: 220px; /* Adjusted height, can be fine-tuned */
+        padding: 1rem;
+        text-align: center;
+        overflow: hidden; /* Ensures pseudo-element doesn't spill if scaled */
     }
-    .mobile-hero-banner img {
-        width: 100%;
-        height: 100%;
-        object-fit: cover; /* Cover ensures the image fills the banner, might crop */
-        object-position: center; /* Center the image within the banner */
-        transition: transform 0.3s ease-out;
-    }
-    .mobile-hero-banner:hover img {
+
+    .mobile-unified-header::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-image: var(--mobile-hero-url); /* Set via inline style in JS */
+        background-size: cover;
+        background-position: center;
+        filter: blur(5px) brightness(0.6);
+        z-index: 1; /* Behind the content */
+        /* Optional: Add a slight scale to prevent blurred edges from showing through */
         transform: scale(1.05);
+    }
+
+    /* Ensure direct children (logo, titles) are above the pseudo-element */
+    .mobile-unified-header > * {
+        position: relative;
+        z-index: 2;
     }
 
     /* Lightbox Styling */
@@ -343,30 +359,34 @@ main {
         color: #fff;
     }
 
-    /* 2. Main Info Block */
-    .mobile-main-info {
-        padding: 1rem 1rem 0.5rem 1rem; /* Reduced bottom padding */
-        text-align: center;
-        background-color: rgba(0,0,0,0.1); /* Subtle background distinction */
-    }
-    .mobile-main-info .mobile-logo { /* Specific selector for mobile logo */
-        max-width: 180px; /* Slightly larger logo */
+    /* 2. Main Info Block - Styles adjusted for .mobile-unified-header */
+    /* Remove background from .mobile-main-info if it was a separate block */
+    /* .mobile-main-info { background-color: transparent; } */ /* Assuming .mobile-main-info is gone */
+
+    .mobile-unified-header .mobile-logo { /* Target logo within the new header */
+        max-width: 180px; /* Retain or adjust size */
         height: auto;
-        max-height: 70px; /* Max height for logo */
-        margin-bottom: 0.75rem;
-        filter: drop-shadow(1px 1px 3px rgba(0,0,0,0.5));
+        max-height: 80px; /* Slightly increased max-height for better presence */
+        margin-bottom: 0.75rem; /* Space between logo and titles */
+        filter: drop-shadow(2px 2px 5px rgba(0,0,0,0.7)); /* Enhanced drop shadow */
     }
-    .mobile-main-info .japanese-title { /* Styles for titles within mobile view */
-        margin-top: 0;
-        margin-bottom: 0.5rem; /* Space after titles */
+    .mobile-unified-header .japanese-title { /* Target titles within the new header */
+        margin-top: 0.25rem; /* Adjust spacing if needed */
+        margin-bottom: 0; /* No bottom margin as it's the last element in its group */
+        text-shadow: 2px 2px 6px rgba(0,0,0,0.9); /* Apply specified text shadow */
     }
-    .mobile-main-info .kanji-title {
-        font-size: var(--font-size-md);
-        color: var(--accent-gold);
+    .mobile-unified-header .kanji-title {
+        font-size: var(--font-size-md); /* Retain or adjust size */
+        color: var(--accent-gold); /* Retain color */
+        line-height: var(--line-height-tight);
     }
-    .mobile-main-info .romaji-title {
-        font-size: var(--font-size-sm);
-        opacity: 0.85;
+    .mobile-unified-header .romaji-title {
+        font-size: var(--font-size-sm); /* Retain or adjust size */
+        opacity: 0.9; /* Slightly increased opacity for better readability */
+        font-family: 'Playfair Display', serif; /* Ensure font consistency if needed */
+        font-style: italic;
+        font-weight: 700;
+        line-height: var(--line-height-tight);
     }
 
     /* 3. Collapsible "Release Details" Section */
@@ -516,51 +536,51 @@ main {
     }
 
     /* Mobile Card Variant Navigation Animations */
-    .game-entry-mobile-card .mobile-hero-banner,
-    .game-entry-mobile-card .mobile-main-info,
-    .game-entry-mobile-card .mobile-release-accordion, /* Target accordion directly if content is part of it */
-    .game-entry-mobile-card .mobile-external-links {
+    .game-entry-mobile-card .mobile-unified-header, /* Updated selector */
+    .game-entry-mobile-card .mobile-release-accordion,
+    .game-entry-mobile-card .mobile-external-links,
+    .game-entry-mobile-card .mobile-pager-dots { /* Added pager dots to animation */
         transition: opacity 0.25s ease-in-out, transform 0.25s ease-in-out;
     }
 
-    .game-entry-mobile-card.card-swiping-out-left .mobile-hero-banner,
-    .game-entry-mobile-card.card-swiping-out-left .mobile-main-info,
+    .game-entry-mobile-card.card-swiping-out-left .mobile-unified-header, /* Updated selector */
     .game-entry-mobile-card.card-swiping-out-left .mobile-release-accordion,
-    .game-entry-mobile-card.card-swiping-out-left .mobile-external-links {
+    .game-entry-mobile-card.card-swiping-out-left .mobile-external-links,
+    .game-entry-mobile-card.card-swiping-out-left .mobile-pager-dots { /* Added pager dots */
         opacity: 0;
         transform: translateX(-30px); /* Slide out to the left */
     }
 
-    .game-entry-mobile-card.card-swiping-out-right .mobile-hero-banner,
-    .game-entry-mobile-card.card-swiping-out-right .mobile-main-info,
+    .game-entry-mobile-card.card-swiping-out-right .mobile-unified-header, /* Updated selector */
     .game-entry-mobile-card.card-swiping-out-right .mobile-release-accordion,
-    .game-entry-mobile-card.card-swiping-out-right .mobile-external-links {
+    .game-entry-mobile-card.card-swiping-out-right .mobile-external-links,
+    .game-entry-mobile-card.card-swiping-out-right .mobile-pager-dots { /* Added pager dots */
         opacity: 0;
         transform: translateX(30px); /* Slide out to the right */
     }
 
     /* Initial state for incoming content (before animation) */
-    .game-entry-mobile-card.card-swiping-in-left .mobile-hero-banner,
-    .game-entry-mobile-card.card-swiping-in-left .mobile-main-info,
+    .game-entry-mobile-card.card-swiping-in-left .mobile-unified-header, /* Updated selector */
     .game-entry-mobile-card.card-swiping-in-left .mobile-release-accordion,
-    .game-entry-mobile-card.card-swiping-in-left .mobile-external-links {
+    .game-entry-mobile-card.card-swiping-in-left .mobile-external-links,
+    .game-entry-mobile-card.card-swiping-in-left .mobile-pager-dots { /* Added pager dots */
         opacity: 0;
         transform: translateX(30px); /* Start off-screen to the right */
     }
 
-    .game-entry-mobile-card.card-swiping-in-right .mobile-hero-banner,
-    .game-entry-mobile-card.card-swiping-in-right .mobile-main-info,
+    .game-entry-mobile-card.card-swiping-in-right .mobile-unified-header, /* Updated selector */
     .game-entry-mobile-card.card-swiping-in-right .mobile-release-accordion,
-    .game-entry-mobile-card.card-swiping-in-right .mobile-external-links {
+    .game-entry-mobile-card.card-swiping-in-right .mobile-external-links,
+    .game-entry-mobile-card.card-swiping-in-right .mobile-pager-dots { /* Added pager dots */
         opacity: 0;
         transform: translateX(-30px); /* Start off-screen to the left */
     }
 
     /* Target state for incoming content (visible and in place) - will transition to this */
-    .game-entry-mobile-card.card-content-visible .mobile-hero-banner,
-    .game-entry-mobile-card.card-content-visible .mobile-main-info,
+    .game-entry-mobile-card.card-content-visible .mobile-unified-header, /* Updated selector */
     .game-entry-mobile-card.card-content-visible .mobile-release-accordion,
-    .game-entry-mobile-card.card-content-visible .mobile-external-links {
+    .game-entry-mobile-card.card-content-visible .mobile-external-links,
+    .game-entry-mobile-card.card-content-visible .mobile-pager-dots { /* Added pager dots */
         opacity: 1;
         transform: translateX(0);
     }


### PR DESCRIPTION
Merge mobile hero banner and main info into a unified component.

Key changes:
- Introduces `.mobile-unified-header` for game cards on mobile.
- Uses the game's hero image as a blurred and darkened background for this new header.
- Layers the game logo and Japanese titles on top of this background.
- Centers foreground content and applies text/drop shadows for readability.
- Adjusts header height and ensures responsive behavior.
- Desktop view and functionality remain unchanged.
- Updates card content and animations for new structure.