### PR TITLE
Fix: Ensure mobile card fills screen width

### DIFF
--- a/style.css
+++ b/style.css
@@ -286,6 +286,8 @@ main {
         overflow: hidden;
         margin-bottom: 1.5rem; /* Spacing between cards */
         border: 1px solid rgba(233, 213, 161, 0.2); /* Subtle gold border */
+        width: 100%; /* Ensure card takes full available width */
+        box-sizing: border-box; /* Include padding and border in the element's total width and height */
     }
 
     /* 1. Unified Mobile Header */


### PR DESCRIPTION
Updated `.game-entry-mobile-card` CSS to include `width: 100%` and `box-sizing: border-box;`.

This ensures the mobile card expands to the full available width within its parent container, respecting the `main` element's padding, rather than collapsing to the width of its content. This addresses the issue where the card width would change when expanding sections like 'Release Details'.

The previously implemented unified mobile header will now also correctly span this full width.