### PR TITLE
Style: Increase logo size in unified mobile header

### DIFF
--- a/style.css
+++ b/style.css
@@ -324,10 +324,10 @@ main {
     }
 
     .mobile-unified-header-content .mobile-logo {
-        max-width: 180px; /* Consistent with old .mobile-main-info .mobile-logo */
-        max-height: 70px; /* Consistent with old .mobile-main-info .mobile-logo */
+        max-width: 240px; /* Increased from 180px */
+        max-height: 100px; /* Increased from 70px */
         height: auto;
-        margin-bottom: 0.75rem; /* Consistent with old .mobile-main-info .mobile-logo */
+        margin-bottom: 1rem; /* Increased from 0.75rem for better spacing */
         filter: drop-shadow(2px 2px 4px rgba(0,0,0,0.7)); /* Match desktop for readability */
     }
 


### PR DESCRIPTION
Updated the CSS for `.mobile-unified-header-content .mobile-logo` to increase `max-width` to 240px (from 180px) and `max-height` to 100px (from 70px).

Also increased `margin-bottom` to 1rem (from 0.75rem) to maintain appropriate spacing with the larger logo.

This change addresses feedback to make the logos larger to better fill the space in the new unified mobile header.