### PR TITLE
Adjust mobile header for true vertical centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -293,7 +293,7 @@ main {
     /* 1. Unified Mobile Header */
     .mobile-unified-header {
         position: relative;
-        height: 210px; /* Fixed height for consistency */
+        /* height: 210px; Fixed height removed to allow content to define height */
         width: 100%;
         overflow: hidden; /* Ensures content respects fixed height */
     }
@@ -317,9 +317,9 @@ main {
         height: 100%;
         display: flex;
         flex-direction: column;
-        justify-content: flex-start; /* Align content to the top */
+        justify-content: center; /* Reverted to center */
         align-items: center;
-        padding: 0.5rem 1rem 1rem 1rem; /* Reduced top padding, kept others */
+        padding: 1.5rem 1rem; /* Adjusted top/bottom padding for balance */
         text-align: center; /* Fallback for text alignment */
     }
 


### PR DESCRIPTION
- Removed fixed height from `.mobile-unified-header`.
- Set `justify-content: center` on `.mobile-unified-header-content`.
- Adjusted `padding` on `.mobile-unified-header-content` to `1.5rem 1rem` to ensure the logo and Japanese titles are vertically centered with balanced spacing above and below.
- This addresses feedback regarding excessive bottom space in the previous iteration.