### PR TITLE
Fix: Simplify mobile slider arrow visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -679,23 +679,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
                 if (!prevBtn || !nextBtn) continue;
 
-                if (i === currentIndex) { // This is the active card
-                    if (itemsCount <= 1) { // Should not happen due to earlier check, but for safety
-                        prevBtn.style.display = 'none';
-                        nextBtn.style.display = 'none';
-                    } else if (currentIndex === 0) { // First slide
-                        prevBtn.style.display = 'none';
-                        nextBtn.style.display = 'flex';
-                    } else if (currentIndex === itemsCount - 1) { // Last slide
-                        prevBtn.style.display = 'flex';
-                        nextBtn.style.display = 'none';
-                    } else { // Slides in between
-                        prevBtn.style.display = 'flex';
-                        nextBtn.style.display = 'flex';
-                    }
-                } else { // This is an inactive card
+                // Visibility depends only on the card's position in the sequence (i)
+                // and the total number of items (itemsCount).
+                // Not on whether i === currentIndex.
+
+                if (itemsCount <= 1) { // Should not be strictly necessary here if initial check in setupSliderControls works
                     prevBtn.style.display = 'none';
                     nextBtn.style.display = 'none';
+                } else {
+                    prevBtn.style.display = (i > 0) ? 'flex' : 'none';
+                    nextBtn.style.display = (i < itemsCount - 1) ? 'flex' : 'none';
                 }
             }
         }


### PR DESCRIPTION
Refactors the `updateMobileButtonsState` function in `script.js` to simplify the visibility logic for mobile navigation arrows.

Previously, arrows on inactive slides were explicitly hidden. Now, the visibility of each mobile card's previous/next arrows depends solely on that card's position within the overall slide sequence (e.g., first card only shows 'next', last card only shows 'prev').

The arrows remain part of their respective card's DOM and will slide in and out with the card, always showing the appropriate controls for that specific card if it were visible.

This simplifies the JavaScript logic while achieving the desired visual effect of arrows being fixed to their cards.