### PR TITLE
Fix: Correct accordion arrow 180-degree rotation

### DIFF
--- a/script.js
+++ b/script.js
@@ -294,7 +294,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     bar.setAttribute('aria-expanded', !isExpanded);
                     if (chevron) {
                         chevron.classList.toggle('expanded', !isExpanded);
-                        chevron.textContent = isExpanded ? '▼' : '▲';
+                        // chevron.textContent = isExpanded ? '▼' : '▲'; // Removed this line
                     }
                 }
             }


### PR DESCRIPTION
The accordion arrow on mobile previously appeared to rotate 360 degrees while maintaining a downward point. This was due to the JavaScript simultaneously changing the chevron's text character (between '▼' and '▲') and toggling a CSS class for a 180-degree rotation.

This commit fixes the issue by removing the JavaScript logic that changes the chevron's text content. The arrow now uses a static '▼' character, and its orientation is solely controlled by the CSS `transform: rotate(180deg)` when the accordion is expanded, ensuring it correctly points upwards.