### PR TITLE
feat: Refine slider navigation for desktop and mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,9 +94,27 @@ document.addEventListener('DOMContentLoaded', () => {
     /**
      * Creates HTML for the desktop info container (background, content).
      * @param {Object} game - The game data object.
+     * @param {boolean} [isSliderItem=false] - Whether this item is part of a slider.
+     * @param {number} [itemIndexInSlider=0] - The index of this item within the slider (0 or 1).
+     * @param {string} [contentStripId=''] - The ID of the content strip this button will control.
      * @returns {string} HTML string for the info container.
      */
-    function createDesktopInfoContainerHTML(game) {
+    function createDesktopInfoContainerHTML(game, isSliderItem = false, itemIndexInSlider = 0, contentStripId = '') {
+        let navButtonHTML = '';
+        if (isSliderItem) {
+            // Arrow direction will be set/updated by JavaScript in setupSliderControls
+            // For now, we can set a default or leave it to be populated by JS.
+            // Let's add a placeholder class or data attribute for easy selection.
+            navButtonHTML = `
+                <button
+                    class="slider-nav-button desktop-only"
+                    data-slider-item-index="${itemIndexInSlider}"
+                    aria-controls="${contentStripId}"
+                >
+                    <!-- Arrow will be populated by JS -->
+                </button>`;
+        }
+
         return `
             <div class="info-container desktop-only">
                 <div class="hero-background" style="background-image: url('hero/${game.assetName}.jpg');" loading="lazy"></div>
@@ -104,18 +122,22 @@ document.addEventListener('DOMContentLoaded', () => {
                     ${createDesktopMainInfoHTML(game)}
                     ${createDesktopExternalLinksHTML(game)}
                 </div>
+                ${navButtonHTML}
             </div>`;
     }
 
     /**
      * Creates the complete HTML for a desktop game entry.
      * @param {Object} game - The game data object.
+     * @param {boolean} [isSliderItem=false] - Whether this item is part of a slider.
+     * @param {number} [itemIndexInSlider=0] - The index of this item within the slider (0 or 1).
+     * @param {string} [contentStripId=''] - The ID of the content strip for the button.
      * @returns {string} HTML string for the desktop game entry.
      */
-    function createGameEntryDesktopHTML(game) {
+    function createGameEntryDesktopHTML(game, isSliderItem = false, itemIndexInSlider = 0, contentStripId = '') {
         return `
             ${createDesktopArtContainerHTML(game)}
-            ${createDesktopInfoContainerHTML(game)}`;
+            ${createDesktopInfoContainerHTML(game, isSliderItem, itemIndexInSlider, contentStripId)}`;
     }
 
     // --- Mobile HTML Generation ---
@@ -209,13 +231,16 @@ document.addEventListener('DOMContentLoaded', () => {
      * @param {boolean} [isVariant=false] - Whether this item is a variant.
      * @param {Array<Object>|null} [allVariantsData=null] - Full list of variants (including main) for mobile card context.
      * @param {string|null} [mainGameAssetName=null] - Asset name of the main game for mobile variant context.
+     * @param {boolean} [isDesktopSliderItem=false] - Flag for desktop slider item.
+     * @param {number} [desktopItemIndex=0] - Index for desktop slider item.
+     * @param {string} [desktopContentStripId=''] - Content strip ID for desktop button.
      * @returns {string} HTML string for the complete game render.
      */
-    function createFullGameRenderHTML(gameData, isVariant = false, allVariantsData = null, mainGameAssetName = null) {
+    function createFullGameRenderHTML(gameData, isVariant = false, allVariantsData = null, mainGameAssetName = null, isDesktopSliderItem = false, desktopItemIndex = 0, desktopContentStripId = '') {
         // For variants, allVariantsData would be the full list [mainGame, variant1, variant2...]
         // and mainGameAssetName would be the assetName of the original game.
         return `
-            ${createGameEntryDesktopHTML(gameData)}
+            ${createGameEntryDesktopHTML(gameData, isDesktopSliderItem, desktopItemIndex, desktopContentStripId)}
             ${createMobileCardHTML(gameData, isVariant, allVariantsData, mainGameAssetName)}
         `;
     }
@@ -366,12 +391,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     originalGameEntry.className = 'game-entry';
                     // For the main game in a slider, pass its full variant data for the mobile card
                     const allVariantDataForMobile = [game, ...game.variants];
-                    originalGameEntry.innerHTML = createFullGameRenderHTML(game, false, allVariantDataForMobile, null);
+                    // For desktop, this is the first item in the slider (index 0)
+                    originalGameEntry.innerHTML = createFullGameRenderHTML(game, false, allVariantDataForMobile, null, true, 0, contentStripId);
                     originalGameItem.appendChild(originalGameEntry);
                     sliderContentStrip.appendChild(originalGameItem);
 
                     // Variant game items
-                    game.variants.forEach(variant => {
+                    game.variants.forEach((variant, index) => { // Assuming only one variant, so index will be 0 here for the variant itself
                         const variantGameItem = document.createElement('div');
                         variantGameItem.className = 'slider-item';
                         variantGameItem.setAttribute('role', 'group');
@@ -379,7 +405,8 @@ document.addEventListener('DOMContentLoaded', () => {
                         const variantGameEntry = document.createElement('div');
                         variantGameEntry.className = 'game-entry';
                         // Pass allVariantDataForMobile so the card knows it's part of a slider context
-                        variantGameEntry.innerHTML = createFullGameRenderHTML(variant, true, allVariantDataForMobile, game.assetName);
+                        // For desktop, this is the second item in the slider (index 1)
+                        variantGameEntry.innerHTML = createFullGameRenderHTML(variant, true, allVariantDataForMobile, game.assetName, true, 1, contentStripId);
                         variantGameItem.appendChild(variantGameEntry);
                         sliderContentStrip.appendChild(variantGameItem);
                     });
@@ -387,20 +414,19 @@ document.addEventListener('DOMContentLoaded', () => {
                     gameEntrySlider.appendChild(sliderContentStrip);
                     sliderDisplayArea.appendChild(gameEntrySlider);
 
-                    // Old prevButton and nextButton code was here, removed.
-
-                    const navButton = document.createElement('button');
-                    navButton.className = 'slider-nav-button desktop-only'; // Added desktop-only
-                    navButton.setAttribute('aria-controls', contentStripId);
-                    // Icon and onclick will be set by navigateSlider, aria-label will be set in setupSliderControls
-                    sliderDisplayArea.appendChild(navButton);
-                    sliderDisplayArea.navButton = navButton; // Store reference to the button
+                    // REMOVE THE OLD SINGLE DESKTOP BUTTON CREATION
+                    // const navButton = document.createElement('button');
+                    // navButton.className = 'slider-nav-button desktop-only';
+                    // navButton.setAttribute('aria-controls', contentStripId);
+                    // sliderDisplayArea.appendChild(navButton);
+                    // sliderDisplayArea.navButton = navButton;
 
                     gameWrapperElement = sliderDisplayArea;
                 } else {
                     const standardEntry = document.createElement('div');
                     standardEntry.className = 'game-entry';
-                    standardEntry.innerHTML = createFullGameRenderHTML(game); // No variants, so no allVariantData needed for mobile here
+                    // For non-slider items, pass false for isDesktopSliderItem
+                    standardEntry.innerHTML = createFullGameRenderHTML(game, false, null, null, false);
                     gameWrapperElement = standardEntry;
                 }
                 timelineContainer.appendChild(gameWrapperElement);
@@ -464,60 +490,62 @@ document.addEventListener('DOMContentLoaded', () => {
      */
     function setupSliderControls(sliderDisplayAreaElement) {
         const contentStrip = sliderDisplayAreaElement.querySelector('.game-entry-slider .slider-content-strip');
-        if (!contentStrip || contentStrip.children.length <= 1) {
-            // Hide all nav buttons if not a true slider (0 or 1 item)
-            const desktopNavButton = sliderDisplayAreaElement.querySelector('.slider-nav-button.desktop-only');
-            if (desktopNavButton) desktopNavButton.style.display = 'none';
+        // Get all new desktop buttons within their respective .info-container
+        const desktopNavButtons = sliderDisplayAreaElement.querySelectorAll('.slider-item .info-container .slider-nav-button.desktop-only');
 
+        if (!contentStrip || contentStrip.children.length <= 1) {
+            // Hide all desktop nav buttons if not a true slider
+            desktopNavButtons.forEach(btn => btn.style.display = 'none');
+
+            // Hide mobile nav buttons as before
             const firstItemMobileCard = contentStrip.querySelector('.slider-item:first-child .game-entry-mobile-card');
             if (firstItemMobileCard) {
-                const mobileNavButton = firstItemMobileCard.querySelector('.slider-nav-button-mobile');
-                if (mobileNavButton) mobileNavButton.style.display = 'none';
+                const mobileNavButtons = firstItemMobileCard.querySelectorAll('.slider-nav-button-mobile');
+                mobileNavButtons.forEach(btn => btn.style.display = 'none');
             }
             return;
         }
 
-        const itemsCount = contentStrip.children.length;
+        const itemsCount = contentStrip.children.length; // Should be 2 for sliders
         let currentIndex = parseInt(sliderDisplayAreaElement.getAttribute('data-current-index'), 10) || 0;
         sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
 
-        const contentStripId = contentStrip.id; // Get the ID from the content strip itself
+        const contentStripId = contentStrip.id;
 
-        const desktopNavButton = sliderDisplayAreaElement.querySelector('.slider-nav-button.desktop-only');
-        // Select all potential mobile nav buttons within this slider area
+        // Mobile buttons setup (remains largely the same)
         const allMobilePrevButtons = sliderDisplayAreaElement.querySelectorAll('.slider-item .mobile-only .slider-nav-mobile-prev');
         const allMobileNextButtons = sliderDisplayAreaElement.querySelectorAll('.slider-item .mobile-only .slider-nav-mobile-next');
-
-        // Set aria-controls for mobile buttons
         allMobilePrevButtons.forEach(btn => btn.setAttribute('aria-controls', contentStripId));
         allMobileNextButtons.forEach(btn => btn.setAttribute('aria-controls', contentStripId));
 
-
         function updateSlidePosition() {
-            // The 2rem gap is defined in CSS for .slider-content-strip gap
             contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
         }
 
-        function updateDesktopButton() {
-            if (!desktopNavButton) return;
-            // itemsCount is at most 2 for a slider with variants.
-            // If itemsCount is 1, the initial check in setupSliderControls hides the button.
-            // This function now assumes itemsCount is 2 if the button is visible.
-            if (itemsCount <= 1) { // This case should ideally be caught by the initial setup
-                desktopNavButton.disabled = true;
-                desktopNavButton.style.display = 'none';
-            } else { // Assumes itemsCount is 2
-                desktopNavButton.style.display = 'flex';
-                desktopNavButton.disabled = false;
-                if (currentIndex === 0) {
-                    desktopNavButton.innerHTML = '&#10095;'; // → (Next)
-                    desktopNavButton.setAttribute('aria-label', 'Next item');
-                } else { // currentIndex must be 1
-                    desktopNavButton.innerHTML = '&#10094;'; // ← (Previous)
-                    desktopNavButton.setAttribute('aria-label', 'Previous item');
-                }
+        function updateDesktopButtonsUI() {
+            if (itemsCount <= 1) { // Should be caught by the initial check
+                desktopNavButtons.forEach(btn => {
+                    btn.style.display = 'none';
+                    btn.disabled = true;
+                });
+                return;
             }
+            // Assuming itemsCount is 2
+            desktopNavButtons.forEach(btn => {
+                const itemIndex = parseInt(btn.dataset.sliderItemIndex, 10);
+                btn.style.display = 'flex'; // Make them visible
+                btn.disabled = false;
+
+                if (itemIndex === 0) { // Button on the first slide
+                    btn.innerHTML = '&#10095;'; // Next arrow
+                    btn.setAttribute('aria-label', 'Next variant');
+                } else { // Button on the second slide (itemIndex === 1)
+                    btn.innerHTML = '&#10094;'; // Previous arrow
+                    btn.setAttribute('aria-label', 'Previous variant');
+                }
+            });
         }
+
 
         function updateMobileButtonsState() {
             // This function is called when a slider has 2 items (original + variant).
@@ -551,11 +579,10 @@ document.addEventListener('DOMContentLoaded', () => {
             // No need to handle itemsCount > 2 as per new constraints.
         }
 
-
-        if (desktopNavButton) {
-            desktopNavButton.onclick = () => {
-                // With max 2 items, currentIndex can only be 0 or 1.
-                // itemsCount will be 2 if this button is active.
+        // Setup new desktop buttons
+        desktopNavButtons.forEach(btn => {
+            btn.onclick = () => {
+                // Toggle logic for 2 items
                 if (currentIndex === 0) {
                     currentIndex = 1;
                 } else {
@@ -563,9 +590,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
                 updateSlidePosition();
-                updateDesktopButton();
+                // updateDesktopButtonsUI(); // UI (arrow/label) doesn't change based on currentIndex for these new buttons, only initial setup.
+                                        // Visibility might change if we hide the button on the *active* slide, but requirement is for them to slide with content.
+                                        // The content of the button (arrow direction) is fixed based on its slide.
             };
-        }
+        });
+
 
         allMobilePrevButtons.forEach(btn => {
             btn.onclick = () => {
@@ -573,7 +603,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     currentIndex--;
                     sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
                     updateSlidePosition();
-                    updateDesktopButton(); // Keep desktop button in sync
+                    // updateDesktopButtonsUI(); // Desktop buttons don't need to react to mobile clicks this way.
                     updateMobileButtonsState();
                 }
             };
@@ -581,11 +611,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         allMobileNextButtons.forEach(btn => {
             btn.onclick = () => {
-                if (currentIndex < itemsCount - 1) {
+                if (currentIndex < itemsCount - 1) { // Should always be 1 for 2 items
                     currentIndex++;
                     sliderDisplayAreaElement.setAttribute('data-current-index', currentIndex.toString());
                     updateSlidePosition();
-                    updateDesktopButton(); // Keep desktop button in sync
+                    // updateDesktopButtonsUI(); // Desktop buttons don't need to react to mobile clicks this way.
                     updateMobileButtonsState();
                 }
             };
@@ -593,7 +623,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Initial setup
         updateSlidePosition();
-        updateDesktopButton();
+        updateDesktopButtonsUI(); // Set initial arrows and labels for new desktop buttons
         updateMobileButtonsState();
     }
 

--- a/style.css
+++ b/style.css
@@ -199,41 +199,43 @@ main {
     /* .game-entry styles will apply to the child div within .slider-item */
 }
 
-/* New styles for the single desktop slider navigation button */
-.slider-nav-button {
+/* Styles for the NEW desktop slider navigation buttons (within .info-container) */
+/* These buttons are identified by .slider-nav-button and .desktop-only */
+.info-container .slider-nav-button.desktop-only {
     position: absolute;
-    bottom: 15px;
-    right: 15px;
-    z-index: 15; /* Ensure it's above hero image, but below potential modals */
-    background-color: rgba(0, 0, 0, 0.6);
-    color: var(--accent-gold);
-    border: 1px solid var(--accent-gold);
-    border-radius: 50%; /* Circular button */
-    width: 44px;
-    height: 44px;
-    font-size: var(--font-size-xl); /* Arrow size */
+    top: 50%; /* Vertically center */
+    transform: translateY(-50%);
+    right: -20px; /* Overhang: adjust this value as needed, half of width approx */
+    width: 40px; /* Sleek rectangle width */
+    height: 50%; /* 50% of info-container height */
+    background-color: rgba(34, 34, 34, 0.7); /* Semi-transparent dark background */
+    color: var(--accent-gold); /* Arrow color */
+    border: none; /* Remove default border */
+    border-radius: 8px; /* Rounded corners */
     cursor: pointer;
-    transition: background-color 0.3s ease, opacity 0.3s ease-out, color 0.3s ease, border-color 0.3s ease;
+    z-index: 10; /* Ensure it's above info-content's background but below modals */
     display: flex;
     align-items: center;
     justify-content: center;
-    line-height: 1;
+    font-size: var(--font-size-xl); /* Arrow size */
+    line-height: 1; /* Ensure arrow is centered if it's text */
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    transition: background-color 0.3s ease, right 0.3s ease, box-shadow 0.3s ease; /* Added right for potential hover effect */
 }
 
-.slider-nav-button:hover {
-    background-color: rgba(0, 0, 0, 0.8);
-    border-color: #fff;
+.info-container .slider-nav-button.desktop-only:hover {
+    background-color: rgba(34, 34, 34, 0.9); /* More opaque on hover */
+    box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+    /* Optional: make it slightly more prominent on hover, e.g., by moving it less off-screen */
+    /* right: -18px; */
 }
 
-.slider-nav-button:disabled {
-    opacity: 0.4;
+.info-container .slider-nav-button.desktop-only:disabled {
+    opacity: 0.5;
     cursor: not-allowed;
-    background-color: rgba(0, 0, 0, 0.3);
-    border-color: var(--text-secondary);
-    color: var(--text-secondary);
+    background-color: rgba(50, 50, 50, 0.4);
 }
 
-/* .slider-item .game-entry specific styling was removed as not needed */
 
 /* --- Initial Hiding of Mobile/Desktop Specific Elements --- */
 /* Mobile elements are hidden by default, shown in media query */
@@ -584,13 +586,13 @@ main {
 
     /* Base styles for Mobile Slider Navigation Buttons */
     .slider-nav-button-mobile { /* This will serve as the base class */
-        width: 40px;
-        height: 40px;
+        width: 35px; /* New width */
+        height: 100px; /* New height */
         background-color: rgba(0, 0, 0, 0.6);
         color: var(--accent-gold);
         border: 1px solid var(--accent-gold);
-        border-radius: 50%;
-        font-size: var(--font-size-lg); /* Arrow size */
+        /* border-radius will be set by specific classes */
+        font-size: var(--font-size-xl); /* Larger arrow for taller button */
         cursor: pointer;
         z-index: 10; /* Above header background, below potential popups */
         display: flex; /* Will be set to flex by JS when shown */
@@ -599,12 +601,13 @@ main {
         line-height: 1; /* Ensure icon is centered vertically */
         transition: background-color 0.3s ease, opacity 0.3s ease-out, color 0.3s ease, border-color 0.3s ease;
         position: absolute; /* Common positioning attribute */
-        bottom: 10px; /* Common positioning attribute */
+        top: 50%;
+        transform: translateY(-50%);
     }
 
     .slider-nav-button-mobile:hover {
         background-color: rgba(0, 0, 0, 0.8);
-        border-color: #fff;
+        border-color: #fff; /* Keep accent on border for hover, or change if desired */
     }
 
     /* Though current JS doesn't explicitly disable them, :disabled styles are good practice */
@@ -616,14 +619,19 @@ main {
         color: var(--text-secondary);
     }
 
-    /* Specific positioning for Next button */
+    /* Specific positioning and D-shape styling for Next button */
     .slider-nav-mobile-next {
-        right: 10px;
+        right: 0; /* Flush to the right edge */
+        border-radius: 15px 0 0 15px; /* D-shape: top-left, bottom-left rounded */
+        /* Correction from plan: Next (right) button should be 0 15px 15px 0 */
+        /* User request: border-radius: 0 15px 15px 0; */
+        border-radius: 0 15px 15px 0; /* Corrected based on user request */
     }
 
-    /* Specific positioning for Previous button */
+    /* Specific positioning and D-shape styling for Previous button */
     .slider-nav-mobile-prev {
-        left: 10px;
+        left: 0; /* Flush to the left edge */
+        border-radius: 15px 0 0 15px; /* D-shape: top-left, bottom-left rounded */
     }
 
     /* Ensure mobile slider items are correctly displayed */


### PR DESCRIPTION
Implements a comprehensive redesign of the game variant slider navigation.

Desktop:
- Replaces the single, static desktop navigation button with individual buttons integrated into each sliding panel's info-container.
- These new buttons slide along with their respective content.
- Desktop buttons are styled as tall, sleek, vertically-oriented rectangles with rounded corners, overhanging the right edge of the info-container.
- Button on the first slide shows 'next' (>) and on the second shows 'prev' (<).

Mobile:
- Repositions mobile navigation buttons to be vertically centered within the mobile header.
- Transforms mobile buttons into larger, pill-shaped elements (100px height, 35px width) for improved tappability.
- Styles mobile buttons to be flush against the absolute left/right edges of the card.
- Implements a "D-shape" border-radius for a modern, integrated look:
    - Next (right) button: rounded on top-right and bottom-right.
    - Prev (left) button: rounded on top-left and bottom-left.

This update enhances usability and visual appeal of the slider navigation across both desktop and mobile layouts, aligning with the project's UI evolution goals.