### PR TITLE
Remove redundant nav-active.js script

### DIFF
--- a/games.html
+++ b/games.html
@@ -9,7 +9,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/favicon.png" type="image/png">
-    <script src="nav-active.js" defer></script>
     <script src="script.js" defer></script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/favicon.png" type="image/png">
     <!-- script.js is not loaded on the Home page -->
-    <script src="nav-active.js" defer></script>
 </head>
 <body>
 

--- a/lore.html
+++ b/lore.html
@@ -9,7 +9,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/favicon.png" type="image/png">
-    <script src="nav-active.js" defer></script>
     <script src="lore-script.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
The nav-active.js script was redundant as the active state of the navigation links is already handled manually in the HTML files. This commit removes the script and its references in the HTML files to clean up the codebase.