### PR TITLE
Refactor: Reprioritize Japanese titles display

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,8 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
             <div class="main-info">
                 <img src="assets/logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="game-logo">
                 <p class="japanese-title">
-                    <span class="kanji-title">${game.japaneseTitleKanji}</span>
                     <span class="romaji-title">${game.japaneseTitleRomaji}</span>
+                    <span class="kanji-title">${game.japaneseTitleKanji}</span>
                 </p>
                 <div class="release-details">
                     <div class="release-region">
@@ -169,8 +169,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     <div class="mobile-unified-header-content">
                         <img src="assets/logo/${game.assetName}.png" alt="${game.englishTitle} Logo" class="mobile-logo" loading="lazy">
                         <p class="japanese-title">
-                            <span class="kanji-title">${game.japaneseTitleKanji}</span>
                             <span class="romaji-title">${game.japaneseTitleRomaji}</span>
+                            <span class="kanji-title">${game.japaneseTitleKanji}</span>
                         </p>
                     </div>
                     ${mobileNavButtonsWithAriaHTML}

--- a/style.css
+++ b/style.css
@@ -153,8 +153,8 @@ main {
 .game-logo { max-width: 80%; max-height: 140px; height: auto; margin-bottom: 0.25rem; /* Reduced margin */ filter: drop-shadow(2px 2px 4px rgba(0,0,0,0.7)); }
 .japanese-title { color: var(--accent-gold); margin: 0.25rem 0 1rem 0; /* Reduced margins */ line-height: var(--line-height-tight); }
 .kanji-title, .romaji-title { display: block; }
-.kanji-title { font-weight: 700; font-size: var(--font-size-lg); }
-.romaji-title { font-family: 'Playfair Display', serif; font-style: italic; font-weight: 700; font-size: var(--font-size-md); opacity: 0.9; }
+.romaji-title { font-family: 'Playfair Display', serif; font-weight: 700; font-size: var(--font-size-lg); opacity: 1; }
+.kanji-title { font-weight: normal; font-size: var(--font-size-md); color: var(--text-secondary); }
 
 /* --- New Release Date Styling --- */
 .release-details { display: flex; flex-direction: column; gap: 0.5rem; /* Reduced gap */ line-height: var(--line-height-normal); }
@@ -387,18 +387,20 @@ main {
         line-height: var(--line-height-tight);
     }
 
-    .mobile-unified-header-content .kanji-title {
-        font-size: var(--font-size-md); /* Consistent with old .mobile-main-info .kanji-title */
-        color: var(--accent-gold);
+    .mobile-unified-header-content .romaji-title {
+        font-size: var(--font-size-md); /* Was kanji-title's size */
+        font-family: 'Playfair Display', serif;
         font-weight: 700;
+        color: var(--accent-gold); /* Was kanji-title's color */
+        opacity: 1; /* Full opacity */
     }
 
-    .mobile-unified-header-content .romaji-title {
-        font-size: var(--font-size-sm); /* Consistent with old .mobile-main-info .romaji-title */
-        opacity: 0.9; /* Consistent with desktop .romaji-title */
-        font-family: 'Playfair Display', serif;
-        font-style: italic;
-        font-weight: 700;
+    .mobile-unified-header-content .kanji-title {
+        font-size: var(--font-size-sm); /* Was romaji-title's size */
+        font-weight: normal; /* Normal weight */
+        color: var(--text-secondary); /* Secondary text color */
+        /* font-style: italic; removed */
+        /* opacity: 0.9; removed, color handles subtlety */
     }
 
     /* 2. REMOVED Main Info Block - styles are now part of .mobile-unified-header */


### PR DESCRIPTION
Swapped the visual hierarchy of Romaji and Kanji titles on game cards for both desktop and mobile views.

- Modified `script.js` to change the HTML order of title elements.
- Updated `style.css` to adjust font sizes, weights, and styles to make Romaji titles primary and Kanji titles secondary.