### PR TITLE
Fix: Ensure mobile card width adapts to screen size

### DIFF
--- a/style.css
+++ b/style.css
@@ -300,7 +300,7 @@ main {
 /* --- Mobile Layout Styles (max-width: 900px) --- */
 @media (max-width: 900px) {
     main {
-        min-width: 0; /* Override desktop min-width */
+        min-width: 0 !important; /* Override desktop min-width */
         padding: 1rem 0.5rem; /* Reduce padding for smaller screens */
     }
 


### PR DESCRIPTION
Updated the CSS for the 'main' element in the mobile media query. Changed `min-width: 0;` to `min-width: 0 !important;` to ensure it correctly overrides the desktop `min-width: 600px;`.

This allows the main container, and consequently the mobile cards (width: 100%), to properly shrink on narrow screens and expand to fill available width on larger mobile screens, resolving issues where cards were cut off or did not utilize full screen width.