### PR TITLE
Refactor: Display Lore Timeline in Three Arc Columns

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -1,78 +1,129 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const timelineContainer = document.getElementById('lore-timeline-container');
     const timelineKeyContainer = document.getElementById('lore-timeline-key');
     const gamesJsonPath = 'games.json';
 
     // --- Configuration ---
-    const pixelsPerMonth = 50; // Height of one month in pixels
-    const yearLabelOffset = 15; // Offset for year labels to be slightly above the month line
-    const gameBoxBaseWidth = 100; // Base width of a game box in pixels
-    const gameBoxMargin = 5; // Horizontal margin between game boxes in case of overlap
-    const timelinePaddingTop = 30; // Top padding inside the timeline container before first entry
+    const pixelsPerMonthVertical = 22; // Vertical space for each month row in the axis
+    const axisAreaTopPadding = 25;     // Padding at the top of the axis/games area before first month line
+    const gameBoxMargin = 4;           // Horizontal margin between overlapping game boxes in the same month slot
+    const gameBoxBaseWidthPercentage = 80; // Default width % for a game box if no overlap. JS will make it smaller if needed.
+    const monthsToShowOnAxis = [1, 4, 7, 10]; // January, April, July, October
 
     // --- Helper Functions ---
     function parseDate(dateStr) {
-        if (!dateStr) return null;
+        if (!dateStr) return { year: 0, month: 0, day: 0, valid: false };
         const [year, month, day] = dateStr.split('-').map(Number);
-        return { year, month, day }; // Keep it simple, focus on year/month
+        return { year, month, day: day || 1, valid: true }; // Default to day 1 if not specified
     }
 
-    function getMonthIndex(year, month, startYear) {
-        return (year - startYear) * 12 + (month - 1);
+    function getMonthName(monthNumber) {
+        const d = new Date();
+        d.setMonth(monthNumber - 1);
+        return d.toLocaleString('en-US', { month: 'long' });
     }
 
-    function getMonthAbbreviation(monthNumber) {
-        const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-        return months[monthNumber -1];
+    function getDayWithOrdinal(day) {
+        if (day > 3 && day < 21) return day + 'th';
+        switch (day % 10) {
+            case 1: return day + "st";
+            case 2: return day + "nd";
+            case 3: return day + "rd";
+            default: return day + "th";
+        }
+    }
+
+    function formatGameDateForDisplay(parsedDate, originalDateString) {
+        const monthName = getMonthName(parsedDate.month);
+        const year = `S${parsedDate.year}`;
+        // Check if the original string included a day part (e.g., "YYYY-MM-DD" vs "YYYY-MM")
+        const showDay = originalDateString && originalDateString.length > 7;
+        if (showDay && parsedDate.day) {
+            return `${monthName} ${getDayWithOrdinal(parsedDate.day)}, ${year}`;
+        }
+        return `${monthName} ${year}`;
+    }
+
+    function determineArcForGame(game) {
+        if (game.arc === "Liberl Arc") return "liberl";
+        if (game.arc === "Crossbell Arc") return "crossbell";
+        if (game.arc === "Erebonia Arc" || game.englishTitle === "Trails into Reverie" || game.englishTitle === "Trails of Cold Steel IV" || game.englishTitle === "Trails of Cold Steel III") return "erebonia";
+        // Special handling for CS series to ensure they are in Erebonia if arc is missing for some reason
+        if (game.englishTitle && game.englishTitle.startsWith("Trails of Cold Steel")) return "erebonia";
+        return null;
+    }
+
+    // Calculate month index from a common epoch for sorting/positioning
+    function getGlobalMonthIndex(pDate) {
+        return pDate.year * 12 + pDate.month;
     }
 
 
-    async function initTimeline() {
-        if (!timelineContainer || !timelineKeyContainer) {
-            console.error('Timeline container or key container not found!');
-            return;
+    async function initTimelines() {
+        if (!timelineKeyContainer) {
+            console.warn('Timeline key container not found! Key will not be rendered.');
         }
 
         try {
             const response = await fetch(gamesJsonPath);
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            const games = await response.json();
+            if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+            let allGames = await response.json();
 
-            // Filter out games without timeline data and parse dates
-            const validGames = games.filter(game => game.timelineStart && game.timelineEnd)
-                .map(game => ({
-                    ...game,
-                    parsedStart: parseDate(game.timelineStart),
-                    parsedEnd: parseDate(game.timelineEnd)
-                }));
+            const processedGames = allGames.map(game => ({
+                ...game,
+                parsedStart: parseDate(game.timelineStart),
+                parsedEnd: parseDate(game.timelineEnd),
+                arcKey: determineArcForGame(game)
+            })).filter(game => game.arcKey && game.parsedStart.valid && game.parsedEnd.valid);
 
-            if (validGames.length === 0) {
-                timelineContainer.innerHTML = '<p>No game data with timeline information available.</p>';
-                return;
-            }
+            // Sort all games initially by start date for correct key generation
+            processedGames.sort((a, b) => getGlobalMonthIndex(a.parsedStart) - getGlobalMonthIndex(b.parsedStart));
+            if (timelineKeyContainer) renderGameKey(processedGames, timelineKeyContainer);
 
-            // Sort games by start date, then by end date as a tie-breaker
-            validGames.sort((a, b) => {
-                if (a.parsedStart.year !== b.parsedStart.year) return a.parsedStart.year - b.parsedStart.year;
-                if (a.parsedStart.month !== b.parsedStart.month) return a.parsedStart.month - b.parsedStart.month;
-                if (a.parsedEnd.year !== b.parsedEnd.year) return a.parsedEnd.year - b.parsedEnd.year;
-                return a.parsedEnd.month - b.parsedEnd.month;
+            const arcsDefinition = {
+                liberl: { containerId: 'liberl-timeline-container', games: [], name: "Liberl Arc" },
+                crossbell: { containerId: 'crossbell-timeline-container', games: [], name: "Crossbell Arc" },
+                erebonia: { containerId: 'erebonia-timeline-container', games: [], name: "Erebonia Arc" },
+            };
+
+            processedGames.forEach(game => {
+                if (arcsDefinition[game.arcKey]) {
+                    arcsDefinition[game.arcKey].games.push(game);
+                }
             });
 
+            for (const arcName in arcsDefinition) {
+                const arcDetails = arcsDefinition[arcName];
+                const containerEl = document.getElementById(arcDetails.containerId);
 
-            renderGameKey(validGames, timelineKeyContainer);
-            renderTimeline(validGames, timelineContainer);
+                if (containerEl) {
+                    if (arcDetails.games.length > 0) {
+                        // Sort games within this specific arc by start date
+                        arcDetails.games.sort((a, b) => getGlobalMonthIndex(a.parsedStart) - getGlobalMonthIndex(b.parsedStart));
+                        renderArcTimelineVertical(arcDetails.games, containerEl, arcName);
+                    } else {
+                        const gamesArea = containerEl.querySelector('.timeline-games-area');
+                        if(gamesArea) gamesArea.innerHTML = `<p style="text-align:center; padding-top:20px;">No timeline data for ${arcDetails.name}.</p>`;
+                    }
+                } else {
+                    console.warn(`Container element not found for arc: ${arcDetails.containerId}`);
+                }
+            }
 
         } catch (error) {
-            console.error('Failed to load or process game data:', error);
-            timelineContainer.innerHTML = `<p>Error loading timeline data: ${error.message}. Please try again later.</p>`;
+            console.error('Failed to load or process game data for timelines:', error);
+            // Display error in all timeline containers if a global error occurs
+            ['liberl-timeline-container', 'crossbell-timeline-container', 'erebonia-timeline-container'].forEach(id => {
+                const c = document.getElementById(id);
+                if (c) {
+                    const gamesArea = c.querySelector('.timeline-games-area');
+                    if (gamesArea) gamesArea.innerHTML = `<p style="text-align:center; color:red; padding-top:20px;">Error loading timeline: ${error.message}</p>`;
+                }
+            });
         }
     }
 
     function renderGameKey(games, keyContainer) {
-        keyContainer.innerHTML = ''; // Clear previous key
+        keyContainer.innerHTML = '';
         const uniqueGamesForKey = [];
         const seenTitles = new Set();
 
@@ -82,189 +133,191 @@ document.addEventListener('DOMContentLoaded', () => {
                 seenTitles.add(game.englishTitle);
             }
         });
-
-        // Sort key items alphabetically by title for consistent order
         uniqueGamesForKey.sort((a,b) => a.title.localeCompare(b.title));
 
         uniqueGamesForKey.forEach(item => {
             const keyItemDiv = document.createElement('div');
             keyItemDiv.className = 'key-item';
-
             const swatch = document.createElement('div');
             swatch.className = 'key-color-swatch';
             swatch.style.backgroundColor = item.color;
-
             const titleSpan = document.createElement('span');
             titleSpan.textContent = item.title;
-
             keyItemDiv.appendChild(swatch);
             keyItemDiv.appendChild(titleSpan);
             keyContainer.appendChild(keyItemDiv);
         });
     }
 
-    function renderTimeline(games, container) {
-        container.innerHTML = ''; // Clear previous timeline
+    function renderArcTimelineVertical(gamesInArc, containerElement, arcKeyName) {
+        const axisArea = containerElement.querySelector('.timeline-axis-area');
+        const gamesArea = containerElement.querySelector('.timeline-games-area');
+        axisArea.innerHTML = ''; // Clear previous content
+        gamesArea.innerHTML = ''; // Clear previous content
 
-        const firstYear = Math.min(...games.map(g => g.parsedStart.year));
-        const lastGame = games.reduce((latest, game) => {
-            return (latest.parsedEnd.year > game.parsedEnd.year ||
-                    (latest.parsedEnd.year === game.parsedEnd.year && latest.parsedEnd.month > game.parsedEnd.month))
-                    ? latest : game;
-        });
-        const lastYear = lastGame.parsedEnd.year;
-        const lastMonthOfLastYear = lastGame.parsedEnd.month;
+        if (gamesInArc.length === 0) return;
 
-        const totalMonths = (lastYear - firstYear) * 12 + lastMonthOfLastYear;
-        const timelineHeight = totalMonths * pixelsPerMonth + timelinePaddingTop + 50; // Extra 50 for bottom padding
-        container.style.minHeight = `${timelineHeight}px`;
+        // Determine the min/max years and months for this specific arc
+        const arcMinDate = gamesInArc[0].parsedStart;
+        const arcMaxDate = gamesInArc.reduce((latest, game) => {
+            return getGlobalMonthIndex(game.parsedEnd) > getGlobalMonthIndex(latest) ? game.parsedEnd : latest;
+        }, gamesInArc[0].parsedEnd);
 
-        const axisDiv = document.createElement('div');
-        axisDiv.className = 'timeline-axis';
-        container.appendChild(axisDiv);
+        const firstYear = arcMinDate.year;
+        const lastYear = arcMaxDate.year;
 
-        // Render Years and Months on Axis
+        let runningMonthOffset = 0; // Tracks the overall month offset from the start of this arc's timeline
+        let lastRenderedYearOnAxis = null;
+
+        // Render Years, Months, and Month Lines
         for (let year = firstYear; year <= lastYear; year++) {
-            const yearLabel = document.createElement('div');
-            yearLabel.className = 'timeline-year';
-            yearLabel.textContent = year;
-            // Position at the start of the first month of this year
-            const yearTopPosition = getMonthIndex(year, 1, firstYear) * pixelsPerMonth + timelinePaddingTop - yearLabelOffset;
-            yearLabel.style.top = `${Math.max(timelinePaddingTop - yearLabelOffset, yearTopPosition)}px`; // Ensure it doesn't go above timelinePaddingTop
-            axisDiv.appendChild(yearLabel);
+            const startMonthInCurrentYearLoop = (year === firstYear) ? arcMinDate.month : 1;
+            const endMonthInCurrentYearLoop = (year === lastYear) ? arcMaxDate.month : 12;
 
-            for (let month = 1; month <= 12; month++) {
-                if (year === lastYear && month > lastMonthOfLastYear) break; // Don't render months after the last game ends
+            // Year Label Logic
+            if (year !== lastRenderedYearOnAxis) {
+                // Calculate Y position for the year label based on the first month it applies to in this loop iteration
+                const yearLabelEffectiveYPos = runningMonthOffset * pixelsPerMonthVertical + axisAreaTopPadding;
 
-                const monthLabel = document.createElement('div');
-                monthLabel.className = 'timeline-month';
-                monthLabel.textContent = getMonthAbbreviation(month);
-                const monthTopPosition = getMonthIndex(year, month, firstYear) * pixelsPerMonth + timelinePaddingTop;
-                monthLabel.style.top = `${monthTopPosition}px`;
-                axisDiv.appendChild(monthLabel);
+                const yearLabel = document.createElement('div');
+                yearLabel.className = 'timeline-year';
+                yearLabel.textContent = `S${year}`;
+                 // Position slightly above the first month line of this year, or at top padding
+                yearLabel.style.top = `${Math.max(axisAreaTopPadding - 10, yearLabelEffectiveYPos - (pixelsPerMonthVertical / 2))}px`;
+                axisArea.appendChild(yearLabel);
+                lastRenderedYearOnAxis = year;
+            }
+
+            for (let month = startMonthInCurrentYearLoop; month <= endMonthInCurrentYearLoop; month++) {
+                const monthYPos = runningMonthOffset * pixelsPerMonthVertical + axisAreaTopPadding;
+
+                if (monthsToShowOnAxis.includes(month)) {
+                    const monthLabel = document.createElement('div');
+                    monthLabel.className = 'timeline-month-label';
+                    monthLabel.textContent = getMonthName(month).substring(0, 3);
+                    monthLabel.style.top = `${monthYPos}px`;
+                    axisArea.appendChild(monthLabel);
+                }
+
+                const monthLine = document.createElement('div');
+                monthLine.className = 'timeline-month-line';
+                monthLine.style.top = `${monthYPos}px`;
+                gamesArea.appendChild(monthLine);
+
+                runningMonthOffset++;
             }
         }
+        const overallTimelineHeight = runningMonthOffset * pixelsPerMonthVertical + axisAreaTopPadding + pixelsPerMonthVertical; // Extra month space at bottom
+        axisArea.style.minHeight = `${overallTimelineHeight}px`;
+        gamesArea.style.minHeight = `${overallTimelineHeight}px`;
 
-        // --- Game Box Rendering with Overlap Management ---
-        const gameElements = []; // To store data for collision detection
+        // Prepare game elements for rendering (calculating top, height)
+        const gameElements = gamesInArc.map(game => {
+            // Calculate month offset from the very first month shown in this arc's axis
+            let gameStartOffsetMonths = 0;
+            for(let y = firstYear; y < game.parsedStart.year; y++) {
+                gameStartOffsetMonths += (y === firstYear) ? (12 - arcMinDate.month + 1) : 12;
+            }
+            if (game.parsedStart.year === firstYear) {
+                gameStartOffsetMonths += game.parsedStart.month - arcMinDate.month;
+            } else { // game starts in a subsequent year
+                gameStartOffsetMonths += game.parsedStart.month -1; // -1 because months are 1-indexed
+            }
 
-        games.forEach(game => {
-            const startIndex = getMonthIndex(game.parsedStart.year, game.parsedStart.month, firstYear);
-            const endIndex = getMonthIndex(game.parsedEnd.year, game.parsedEnd.month, firstYear);
+            let gameEndOffsetMonths = 0;
+            for(let y = firstYear; y < game.parsedEnd.year; y++) {
+                gameEndOffsetMonths += (y === firstYear) ? (12 - arcMinDate.month + 1) : 12;
+            }
+            if (game.parsedEnd.year === firstYear) {
+                gameEndOffsetMonths += game.parsedEnd.month - arcMinDate.month;
+            } else {
+                gameEndOffsetMonths += game.parsedEnd.month -1;
+            }
 
-            const top = startIndex * pixelsPerMonth + timelinePaddingTop;
-            // Height calculation: ensure at least a small visible height even for same-month events
-            const durationMonths = (endIndex - startIndex) + 1; // +1 because e.g. Jan to Jan is 1 month duration
-            const height = Math.max(durationMonths * pixelsPerMonth - 5, pixelsPerMonth / 2); // -5 for a small gap, min height half a month
+            const top = gameStartOffsetMonths * pixelsPerMonthVertical + axisAreaTopPadding;
+            const durationInDisplayMonths = Math.max(gameEndOffsetMonths - gameStartOffsetMonths + 1, 1);
+            const height = durationInDisplayMonths * pixelsPerMonthVertical - (pixelsPerMonthVertical > 10 ? 2 : 0); // Small gap
 
-            const gameElement = {
-                id: game.assetName, // For debugging or future use
-                top: top,
-                bottom: top + height,
-                height: height,
-                color: game.timelineColor,
-                title: game.englishTitle,
-                start: `${getMonthAbbreviation(game.parsedStart.month)} ${game.parsedStart.year}`,
-                end: `${getMonthAbbreviation(game.parsedEnd.month)} ${game.parsedEnd.year}`,
-                originalData: game // Keep original data if needed
+            return {
+                ...game,
+                displayTop: top,
+                displayHeight: Math.max(height, pixelsPerMonthVertical * 0.75),
+                overlapStart: top,
+                overlapEnd: top + Math.max(height, pixelsPerMonthVertical * 0.75),
             };
-            gameElements.push(gameElement);
         });
 
-        // Collision detection and column assignment
-        // This is a simplified approach: it assigns columns greedily.
-        // More sophisticated layout algorithms could be used for optimal packing.
-        gameElements.forEach(el => el.column = 0); // Initialize column
+        // Collision detection and column assignment (horizontal within the gamesArea)
+        gameElements.forEach(el => el.assignedHColumn = 0); // Initialize horizontal column
 
         for (let i = 0; i < gameElements.length; i++) {
-            let currentCol = 0;
+            let currentHCol = 0;
             let placed = false;
             while(!placed) {
                 let collision = false;
-                for (let j = 0; j < i; j++) { // Check against previously placed items
-                    if (gameElements[j].column === currentCol) { // Only check if they are trying for the same column
-                        // Check for vertical overlap
-                        if (gameElements[i].top < gameElements[j].bottom && gameElements[i].bottom > gameElements[j].top) {
+                for (let j = 0; j < i; j++) {
+                    if (gameElements[j].assignedHColumn === currentHCol) {
+                        if (gameElements[i].overlapStart < gameElements[j].overlapEnd && gameElements[i].overlapEnd > gameElements[j].overlapStart) {
                             collision = true;
                             break;
                         }
                     }
                 }
                 if (!collision) {
-                    gameElements[i].column = currentCol;
+                    gameElements[i].assignedHColumn = currentHCol;
                     placed = true;
                 } else {
-                    currentCol++; // Try next column
+                    currentHCol++;
                 }
             }
         }
 
-        const maxColumns = Math.max(...gameElements.map(el => el.column)) + 1;
-        // The timeline container has 100px padding-left where the 90px axisDiv sits.
-        // So, game content area starts effectively 100px from the left edge of timelineContainer.
-        // clientWidth is the width of the content area (excluding padding if box-sizing is content-box, which is default for divs).
-        // However, since axisDiv is position:absolute and inside timelineContainer, its width doesn't directly subtract from clientWidth in a flow sense.
-        // The game boxes are positioned relative to timelineContainer's content box.
-        // The available width for game boxes is the timelineContainer's content width MINUS the space we want to reserve on the right.
-        const contentAreaWidth = container.clientWidth; // This is the width games can actually use.
-        const rightPadding = 10; // Small padding on the right of the game area.
-        const availableGameAreaWidth = contentAreaWidth - rightPadding;
-
+        const maxHColumnsNeeded = Math.max(0,...gameElements.map(el => el.assignedHColumn)) + 1;
+        const availableGameAreaWidth = gamesArea.clientWidth > 0 ? gamesArea.clientWidth : (containerElement.clientWidth * 0.7); // Estimate if not rendered
 
         gameElements.forEach(elData => {
             const gameDiv = document.createElement('div');
             gameDiv.className = 'timeline-game-entry';
-            gameDiv.style.backgroundColor = elData.color;
-            gameDiv.style.top = `${elData.top}px`;
-            gameDiv.style.height = `${elData.height}px`;
-            gameDiv.title = `${elData.title} (${elData.start} - ${elData.end})`; // Add tooltip
+            gameDiv.style.backgroundColor = elData.timelineColor;
+            gameDiv.style.top = `${elData.displayTop}px`;
+            gameDiv.style.height = `${elData.displayHeight}px`;
 
-            // Calculate width for each box
-            const minBoxWidth = 40; // Minimum sensible width for a box to be somewhat readable
-            let calculatedWidth = (availableGameAreaWidth - (maxColumns > 1 ? (maxColumns - 1) * gameBoxMargin : 0)) / maxColumns;
-            calculatedWidth = Math.max(calculatedWidth, minBoxWidth);
+            const boxWidth = Math.max(
+                (availableGameAreaWidth / maxHColumnsNeeded) - (gameBoxMargin * (maxHColumnsNeeded > 1 ? (maxHColumnsNeeded -1)/maxHColumnsNeeded : 0) ), // Distribute width
+                (gameBoxBaseWidthPercentage / maxHColumnsNeeded) * (availableGameAreaWidth/100) // Ensure a % of base as min
+            );
 
-            gameDiv.style.width = `${calculatedWidth}px`;
+            gameDiv.style.width = `${Math.max(boxWidth, 30)}px`; // Absolute min width 30px
+            gameDiv.style.left = `${elData.assignedHColumn * (parseFloat(gameDiv.style.width) + gameBoxMargin) + gameBoxMargin}px`;
 
-            // Calculate left position for each box
-            // The gameBoxMargin on the left of the first column pushes it slightly from the axis line.
-            // The axis line is at 90px, container padding-left is 100px. Game content starts effectively at 100px from container's border.
-            // So left: gameBoxMargin (e.g. 5px) means it's 5px into the game content area, which is 105px from container's actual left border.
-            // This is fine.
-            gameDiv.style.left = `${(elData.column * (calculatedWidth + gameBoxMargin)) + gameBoxMargin}px`;
+            const titleSpan = document.createElement('span');
+            titleSpan.className = 'game-title';
+            titleSpan.textContent = elData.englishTitle;
 
-            const titleDiv = document.createElement('div');
-            titleDiv.className = 'game-title';
-            titleDiv.textContent = elData.title;
+            const datesSpan = document.createElement('span');
+            datesSpan.className = 'game-dates';
+            datesSpan.textContent = `${formatGameDateForDisplay(elData.parsedStart, elData.timelineStart)} - ${formatGameDateForDisplay(elData.parsedEnd, elData.timelineEnd)}`;
 
-            const durationDiv = document.createElement('div');
-            durationDiv.className = 'game-duration';
-            durationDiv.textContent = `${elData.start} - ${elData.end}`;
+            gameDiv.appendChild(titleSpan);
+            if (elData.displayHeight > 35) { // Only add dates if there's enough space
+                 gameDiv.appendChild(datesSpan);
+            }
+            gameDiv.title = `${elData.englishTitle}\n(${datesSpan.textContent})`;
 
-            // Text color check (simple version based on brightness)
-            const bgColor = elData.color.startsWith('#') ? elData.color : '#000000'; // default to black if not hex
-            const r = parseInt(bgColor.slice(1, 3), 16);
-            const g = parseInt(bgColor.slice(3, 5), 16);
-            const b = parseInt(bgColor.slice(5, 7), 16);
+
+            // Adjust text color for contrast
+            const r = parseInt(elData.timelineColor.slice(1, 3), 16);
+            const g = parseInt(elData.timelineColor.slice(3, 5), 16);
+            const b = parseInt(elData.timelineColor.slice(5, 7), 16);
             const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-            if (brightness < 128) { // Dark background
-                gameDiv.style.color = '#f0f0f0';
-            } else { // Light background
-                gameDiv.style.color = '#1a1a1a';
-                if (brightness > 230) { // Very light, add darker border
-                     gameDiv.style.borderColor = '#555555';
-                }
+            gameDiv.style.color = brightness < 128 ? '#f0f0f0' : '#1a1a1a';
+            if (brightness > 230 && gameDiv.style.borderColor !== 'rgb(85, 85, 85)') { // Check if already set
+                gameDiv.style.borderColor = '#555555';
             }
 
-
-            gameDiv.appendChild(titleDiv);
-            if (elData.height > 40) { // Only show duration if box is tall enough
-                 gameDiv.appendChild(durationDiv);
-            }
-
-            container.appendChild(gameDiv);
+            gamesArea.appendChild(gameDiv);
         });
     }
 
-    initTimeline();
+    initTimelines();
 });

--- a/lore.html
+++ b/lore.html
@@ -26,9 +26,44 @@
         <div id="lore-timeline-key">
             <!-- Game color key will be generated here by JavaScript -->
         </div>
-        <div id="lore-timeline-container">
-            <!-- Lore timeline will be generated here by JavaScript -->
+
+        <div id="all-arc-timelines-wrapper">
+            <div class="arc-timeline-section">
+                <h2>Liberl Arc Timeline</h2>
+                <div id="liberl-timeline-container" class="arc-timeline-content">
+                <div class="timeline-axis-area">
+                    <!-- Liberl Axis (Years/Months) will be generated here -->
+                </div>
+                <div class="timeline-games-area">
+                    <!-- Liberl Game Boxes will be generated here -->
+                </div>
+            </div>
         </div>
+
+        <div class="arc-timeline-section">
+            <h2>Crossbell Arc Timeline</h2>
+            <div id="crossbell-timeline-container" class="arc-timeline-content">
+                <div class="timeline-axis-area">
+                    <!-- Crossbell Axis (Years/Months) will be generated here -->
+                </div>
+                <div class="timeline-games-area">
+                    <!-- Crossbell Game Boxes will be generated here -->
+                </div>
+            </div>
+        </div>
+
+        <div class="arc-timeline-section">
+            <h2>Erebonia Arc Timeline</h2>
+            <div id="erebonia-timeline-container" class="arc-timeline-content">
+                <div class="timeline-axis-area">
+                    <!-- Erebonia Axis (Years/Months) will be generated here -->
+                </div>
+                <div class="timeline-games-area">
+                    <!-- Erebonia Game Boxes (including Reverie) will be generated here -->
+                </div>
+            </div>
+        </div>
+        </div> <!-- Close all-arc-timelines-wrapper -->
     </main>
 
     <footer>

--- a/style.css
+++ b/style.css
@@ -625,71 +625,114 @@ main {
     border-radius: 3px;
 }
 
-#lore-timeline-container {
-    position: relative;
-    width: 90%; /* Adjust as needed */
-    max-width: 1000px; /* Adjust as needed */
-    margin: 0 auto;
-    padding-left: 100px; /* Space for the year/month axis */
-    min-height: 1500px; /* Default min height, JS will adjust */
-    background-color: rgba(0,0,0,0.1); /* Subtle background for the timeline area */
-    border-radius: 8px;
-    padding-bottom: 50px; /* Space at the bottom */
+/* --- Overall Arc Timelines Wrapper --- */
+#all-arc-timelines-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between; /* Or space-around if padding is desired on sides */
+    gap: 1.5rem; /* Gap between arc columns */
+    margin-top: 1rem;
 }
 
-.timeline-axis {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 90px; /* Width of the axis labels area */
-    padding-top: 20px; /* Align with game box content */
+/* --- Arc Timeline Section Styles (Each Column) --- */
+.arc-timeline-section {
+    flex: 1; /* Each arc column takes equal width */
+    min-width: 300px; /* Minimum width for an arc column */
+    padding: 1rem;
+    background-color: rgba(0,0,0,0.05);
+    border-radius: 8px;
+    border: 1px solid rgba(var(--accent-gold-rgb, 233, 213, 161), 0.2);
+    /* remove margin-bottom if it's now part of a flex row handled by gap */
+}
+
+.arc-timeline-section h2 {
+    text-align: center;
+    color: var(--accent-gold);
+    font-family: 'Playfair Display', serif;
+    font-size: var(--font-size-xl);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(var(--accent-gold-rgb, 233, 213, 161), 0.3);
+    padding-bottom: 0.75rem;
+}
+
+.arc-timeline-content { /* Replaces #lore-timeline-container functionality per arc */
+    display: flex; /* Key for side-by-side axis and games area */
+    position: relative; /* For absolute positioning of game boxes and month lines within games-area */
+    /* min-height will be set by JS per arc based on its content */
+}
+
+.timeline-axis-area {
+    width: 80px; /* Fixed width for year/month labels */
+    flex-shrink: 0; /* Prevent shrinking */
+    position: relative; /* For positioning year/month labels within it */
+    padding-top: 10px; /* Small top padding */
     border-right: 2px solid var(--accent-gold);
 }
 
+.timeline-games-area {
+    flex-grow: 1; /* Takes remaining width */
+    position: relative; /* Crucial: game boxes and month lines are positioned relative to this */
+    padding-left: 10px; /* Small gap between axis line and start of game boxes/month lines */
+    /* min-height will be effectively determined by the axis area or JS calculation */
+}
+
+/* Styles for Year and Month labels - similar to before but within .timeline-axis-area */
 .timeline-year {
-    font-size: var(--font-size-lg);
+    font-size: var(--font-size-md); /* Slightly smaller for compactness */
     font-weight: bold;
     color: var(--accent-gold);
-    position: absolute; /* Positioned by JS */
-    transform: translateY(-50%); /* Center vertically against its calculated top */
-    padding-right:10px; /* Space from the axis line */
-    right: 5px; /* Align to the right of the axis area */
+    position: absolute;
+    transform: translateY(-50%);
+    right: 8px; /* Distance from the axis line */
     text-align: right;
+    width: calc(100% - 10px); /* Ensure it doesn't overflow into games area */
 }
 
-.timeline-month {
+.timeline-month-label { /* Renamed from .timeline-month to avoid conflict if old class is cached/used */
     font-size: var(--font-size-xs);
     color: var(--text-secondary);
-    position: absolute; /* Positioned by JS */
-    transform: translateY(-50%); /* Center vertically */
-    padding-right:5px; /* Space from the axis line */
-    right: 0; /* Align to the right of the axis area */
-    text-align: right;
-}
-
-.timeline-game-entry {
     position: absolute;
-    width: 120px; /* Default width, can be adjusted by JS for overlaps */
-    min-height: 20px; /* Minimum height for very short duration games */
-    padding: 0.5rem;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: var(--text-primary); /* Default text color, can be overridden if needed based on bg */
-    font-size: var(--font-size-sm);
-    line-height: var(--line-height-tight);
-    display: flex;
-    flex-direction: column;
-    justify-content: center; /* Center text vertically */
-    align-items: center; /* Center text horizontally */
-    text-align: center;
-    cursor: default; /* Or pointer if we add interactivity */
-    border: 1px solid rgba(255,255,255,0.3); /* Add a subtle border */
+    transform: translateY(-50%);
+    right: 5px; /* Distance from the axis line */
+    text-align: right;
+    width: calc(100% - 10px);
 }
 
-.timeline-game-entry .game-title {
+/* Horizontal Month Lines */
+.timeline-month-line {
+    position: absolute;
+    left: 0; /* Start from the very left of .timeline-games-area (respecting its padding) */
+    right: 0; /* Extend to the very right of .timeline-games-area */
+    height: 1px;
+    background-color: rgba(var(--text-secondary-rgb, 153, 153, 185), 0.2); /* Faint line */
+    z-index: 0; /* Behind game boxes */
+}
+
+/* Game Entry Styling for Vertical Timeline (within each arc column) */
+.timeline-game-entry {
+    position: absolute; /* Positioned by JS: top based on start month, left/width by overlap logic */
+    /* height is dynamic based on duration, set by JS */
+    min-height: 20px; /* Minimum height for very short duration games */
+    padding: 0.4rem; /* Reduced padding for compactness */
+    border-radius: 4px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.25);
+    overflow: hidden;
+    color: var(--text-primary);
+    font-size: var(--font-size-xs); /* Smaller font for more info in less space */
+    line-height: var(--line-height-tight);
+    text-align: center; /* Center text within the box */
+    cursor: default;
+    border: 1px solid rgba(255,255,255,0.25);
+    z-index: 1; /* Above month lines */
+    box-sizing: border-box;
+    display: flex; /* For centering content */
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
+.timeline-game-entry .game-title { /* For title within the box */
     font-weight: bold;
     margin-bottom: 0.25rem;
 }


### PR DESCRIPTION
- Page Layout: Timelines for Liberl, Crossbell, and Erebonia arcs are now displayed side-by-side in three distinct columns.
- Per-Arc Timelines: Within each arc's column, the timeline runs vertically (top-to-bottom).
  - Games are positioned based on start/end dates along this vertical axis.
  - Height of game boxes represents duration.
  - Overlapping games within an arc are offset horizontally into sub-columns.
- Axis Display:
  - Vertical axis on the left of each arc column shows years (e.g., "S1204") and specific months (Jan, Apr, Jul, Oct).
  - Horizontal lines span each arc's game area for every month.
- Date Formatting:
  - Years on axis and in game boxes are prefixed with "S".
  - Game boxes display full month names (e.g., "January S1202" or "April 15th, S1206").
- Compactness: Reduced vertical spacing for a more compact timeline display.
- HTML: Updated to create a wrapper for the three arc columns and maintain structure for axis/game areas within each.
- CSS: Styles updated for the three-column flex layout, and for the vertical timeline elements within each column.
- JavaScript: Major revisions to handle data grouping per arc, rendering of individual vertical timelines, updated date/axis formatting, and per-arc overlap logic.