### PR TITLE
Fix: Ensure games render despite invalid timelineColor data

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -211,12 +211,33 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                     gameDiv.title = `${game.englishTitle}\n(${startDateStr} - ${endDateStr})`;
 
-                    const r = parseInt(game.timelineColor.slice(1, 3), 16);
-                    const g = parseInt(game.timelineColor.slice(3, 5), 16);
-                    const b = parseInt(game.timelineColor.slice(5, 7), 16);
-                    const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-                    gameDiv.style.color = brightness < 128 ? '#f0f0f0' : '#1a1a1a';
-                    if (brightness > 230) gameDiv.style.borderColor = '#555555';
+                    // Robust color handling
+                    if (game.timelineColor && typeof game.timelineColor === 'string' && game.timelineColor.startsWith('#') && game.timelineColor.length === 7) {
+                        gameDiv.style.backgroundColor = game.timelineColor;
+                        try {
+                            const r = parseInt(game.timelineColor.slice(1, 3), 16);
+                            const g = parseInt(game.timelineColor.slice(3, 5), 16);
+                            const b = parseInt(game.timelineColor.slice(5, 7), 16);
+                            // Check if parsing was successful (they are numbers)
+                            if (!isNaN(r) && !isNaN(g) && !isNaN(b)) {
+                                const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+                                gameDiv.style.color = brightness < 128 ? '#f0f0f0' : '#1a1a1a';
+                                if (brightness > 230) gameDiv.style.borderColor = '#555555';
+                            } else {
+                                // Fallback if hex parsing failed unexpectedly
+                                gameDiv.style.color = '#1a1a1a';
+                                console.warn(`Failed to parse color components for ${game.englishTitle}: ${game.timelineColor}`);
+                            }
+                        } catch (e) {
+                            console.warn(`Error parsing timelineColor for ${game.englishTitle}: ${game.timelineColor}`, e);
+                            gameDiv.style.backgroundColor = '#CCCCCC'; // Default grey
+                            gameDiv.style.color = '#1a1a1a';
+                        }
+                    } else {
+                        console.warn(`Missing or invalid timelineColor for ${game.englishTitle}: '${game.timelineColor}'. Defaulting background.`);
+                        gameDiv.style.backgroundColor = '#CCCCCC'; // Default grey
+                        gameDiv.style.color = '#1a1a1a';
+                    }
 
                     targetColumn.appendChild(gameDiv);
                 });


### PR DESCRIPTION
- Addresses an issue where games were not appearing on the timeline, likely due to errors in processing `timelineColor` from `games.json`.
- Made `timelineColor` handling in `lore-script.js` more robust:
  - Checks if `timelineColor` is a valid string and hex format before attempting to parse it.
  - Uses default background and text colors if `timelineColor` is missing, invalid, or causes a parsing error.
  - Logs a console warning when problematic color data is encountered, instead of letting the script halt.
- This change ensures that all processable games are rendered, improving the timeline's resilience to inconsistent data.