### PR TITLE
Fix: Remove 'Jan' from Lore Timeline month display

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -129,7 +129,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 firstYearRendered = false;
             }
 
-            if (labeledMonths.includes(currentMonth - 1)) {
+            // Only render month label if it's one of the designated labeledMonths AND it's not January
+            if (labeledMonths.includes(currentMonth - 1) && monthNames[currentMonth - 1] !== "Jan") {
                 const monthLabel = document.createElement('div');
                 monthLabel.classList.add('month-label');
                 monthLabel.textContent = monthNames[currentMonth - 1];


### PR DESCRIPTION
Updated lore-script.js to prevent the rendering of 'Jan' month labels in the timeline. Year labels and other month labels (Apr, Jul, Oct) remain unaffected. This change addresses the visual overlap between the year and 'Jan' label.