### PR TITLE
Fix: Adjust timeline label visibility

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -95,23 +95,13 @@ document.addEventListener('DOMContentLoaded', () => {
         let paddedMinMonth = minDate.month - 3;
         let paddedMinYear = minDate.year;
         if (paddedMinMonth <= 0) { paddedMinMonth += 12; paddedMinYear--; }
-
-        // Ensure timeline starts no earlier than S1202, January
-        const timelineStartYearCap = 1202;
-        if (paddedMinYear < timelineStartYearCap) {
-            paddedMinYear = timelineStartYearCap;
-            paddedMinMonth = 1; // Start from January of the cap year
-        } else if (paddedMinYear === timelineStartYearCap && paddedMinMonth < 1) {
-            // This case should ideally not be hit if logic is sound, but as a safeguard
-            paddedMinMonth = 1;
-        }
         minDate = { year: paddedMinYear, month: paddedMinMonth };
 
         let paddedMaxMonth = maxDate.month + 3;
         let paddedMaxYear = maxDate.year;
         if (paddedMaxMonth > 12) { paddedMaxMonth -= 12; paddedMaxYear++; }
         maxDate = { year: paddedMaxYear, month: paddedMaxMonth };
-        console.log("Timeline Range (Padded & Capped):", minDate, "to", maxDate);
+        console.log("Timeline Range (Padded):", minDate, "to", maxDate);
     }
 
     function renderTimeAxis() {
@@ -131,11 +121,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
         while (currentYear < maxDate.year || (currentYear === maxDate.year && currentMonth <= maxDate.month)) {
             if (currentMonth === 1 || firstYearRendered) {
-                const yearLabel = document.createElement('div');
-                yearLabel.classList.add('year-label');
-                yearLabel.textContent = `S${currentYear}`;
-                yearLabel.style.top = `${yOffset - (firstYearRendered ? 0 : 8)}px`;
-                timeAxisContainer.appendChild(yearLabel);
+                // Only render year label if it's not S1201
+                if (currentYear !== 1201) {
+                    const yearLabel = document.createElement('div');
+                    yearLabel.classList.add('year-label');
+                    yearLabel.textContent = `S${currentYear}`;
+                    yearLabel.style.top = `${yOffset - (firstYearRendered ? 0 : 8)}px`;
+                    timeAxisContainer.appendChild(yearLabel);
+                }
                 firstYearRendered = false;
             }
 


### PR DESCRIPTION
- Remove 'Jan' month labels to prevent overlap with year display.
- Specifically hide the 'S1201' year label while retaining its data and month lines.