### PR TITLE
Refactor: Display specific game info below box in lore timeline

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -295,6 +295,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const gameEntryDiv = document.createElement('div');
             gameEntryDiv.className = 'game-entry-box'; // Use className for single class, or classList.add for multiple
+
+            // Apply special class for specific games
+            const specialGames = ["Trails in the Sky the 3rd", "Trails of Cold Steel IV", "Trails into Reverie"];
+            if (specialGames.includes(game.englishTitle)) {
+                gameEntryDiv.classList.add('special-info-below');
+            }
+
             Object.assign(gameEntryDiv.style, {
                 top: `${topPosition}px`, height: `${entryHeight}px`,
                 backgroundColor: game.timelineColor, color: getTextColorForBackground(game.timelineColor),

--- a/style.css
+++ b/style.css
@@ -427,8 +427,54 @@ main {
     justify-content: center; /* Center content vertically if space allows */
     align-items: center; /* Center content horizontally */
     text-align: center;
+    /* overflow: hidden; is the default here, which is good for standard boxes */
 }
 
+/* Styles for special game entries where info is displayed below the box */
+.game-entry-box.special-info-below {
+    overflow: visible !important; /* Crucial: allow text to appear outside the box boundaries */
+    /* Reset padding as text is no longer inside affecting this */
+    padding: 0;
+    /* The flex properties for centering text inside are not needed here as text is absolute */
+}
+
+.game-entry-box.special-info-below .game-entry-title,
+.game-entry-box.special-info-below .game-entry-duration {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    color: white;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.8); /* Slightly softer, darker shadow for better blending */
+    width: auto; /* Fit content */
+    min-width: 150px; /* Prevent very narrow text block if title is short */
+    max-width: 200px; /* Allow some wrapping for longer titles/dates */
+    text-align: center;
+    /* These will not inherit the parent's text color by default if it was changed by JS based on background */
+}
+
+.game-entry-box.special-info-below .game-entry-title {
+    /* Positioned relative to the bottom of the .game-entry-box */
+    /* H is height of .game-entry-box. We want it below. */
+    /* 'bottom' positions relative to the padding edge of the container. */
+    /* Let's use 'top: 100%' to position it right below the box, then margin-top for spacing. */
+    top: 100%;
+    margin-top: 5px; /* Space between box and title */
+    font-size: var(--font-size-sm);
+    font-weight: bold; /* Explicitly set as it might be reset */
+    line-height: var(--line-height-tight);
+}
+
+.game-entry-box.special-info-below .game-entry-duration {
+    /* This will be positioned relative to the title if we nest, or also absolutely */
+    /* For simplicity, also position it absolutely, below the title */
+    top: 100%; /* Start from below the box */
+    margin-top: 22px; /* Space for title (approx 15px height + 5px margin) + 2px gap */
+    font-size: var(--font-size-xs);
+    line-height: var(--line-height-tight);
+    opacity: 0.9; /* Slight opacity for duration */
+}
+
+/* Ensure the default title/duration styles don't conflict when text is inside */
 .game-entry-title {
     font-weight: bold;
     font-size: var(--font-size-sm);


### PR DESCRIPTION
For 'Trails in the Sky the 3rd', 'Trails of Cold Steel IV', and 'Trails into Reverie', this change modifies the lore timeline display.

- The game title and dates for these entries are now positioned below their respective colored boxes.
- Text is styled with white color and a drop shadow for improved readability against the page background and varying box colors.
- Other game entries in the timeline remain unaffected.

This involved:
- Adding a special CSS class in `lore-script.js` to the targeted game entries.
- Defining CSS rules in `style.css` to handle the new layout and text styling for these specific entries, ensuring `overflow: visible` and using absolute positioning for the text elements.