### PR TITLE
Fix: Correct display of special timeline entries

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,9 +445,7 @@ main {
     transform: translateX(-50%);
     color: white;
     text-shadow: 1px 1px 3px rgba(0,0,0,0.8); /* Slightly softer, darker shadow for better blending */
-    width: auto; /* Fit content */
-    min-width: 150px; /* Prevent very narrow text block if title is short */
-    /* max-width: 200px; Let's allow it to be wider if needed, up to the column width. The game-entry-box width is 90% of the column. */
+    width: auto; /* Fit content by default */
     text-align: center;
     /* These will not inherit the parent's text color by default if it was changed by JS based on background */
 }
@@ -458,6 +456,9 @@ main {
     font-size: var(--font-size-sm);
     font-weight: bold;
     line-height: var(--line-height-tight);
+    min-width: 150px; /* Minimum width for the title */
+    max-width: 280px; /* Max width before title wraps, can be adjusted */
+                       /* Game boxes are 90% of column. Columns are ~1/3 of ~1300px = ~430px. 90% of that is ~380px. So 280px is reasonable. */
 }
 
 .game-entry-box.special-info-below .game-entry-duration {
@@ -466,6 +467,7 @@ main {
     font-size: var(--font-size-xs);
     line-height: var(--line-height-tight);
     opacity: 0.9;
+    white-space: nowrap; /* Prevent dates from wrapping */
 }
 
 /* Ensure the default title/duration styles don't conflict when text is inside */


### PR DESCRIPTION
This commit resolves multiple issues related to displaying information below the box for specific timeline entries ('Trails in the Sky the 3rd', 'Trails of Cold Steel IV', 'Trails into Reverie'):

1.  **Ensures Dates are Displayed**: Previously, dates (duration) were not appearing for shorter special entries due to a height-based conditional rendering. Modified `lore-script.js` to always create and show the duration element for these specific games.

2.  **Prevents Unnecessary Text Wrapping**: Dates and titles were wrapping prematurely. Adjusted `style.css` for these elements:
    - Applied `white-space: nowrap;` to the duration string to keep it on a single line.
    - Set appropriate `min-width` and `max-width` for titles to allow wrapping only for genuinely long content, preventing premature breaks.

The result is that the specified game entries now correctly and robustly display both their title and dates below their respective colored boxes, with white text and a drop shadow for readability. Other game entries in the timeline remain unaffected.