### PR TITLE
Refine: Finalize date display logic for lore timeline

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -332,16 +332,14 @@ document.addEventListener('DOMContentLoaded', () => {
             gameEntryDiv.appendChild(titleEl);
 
             let durationStr;
-            // startDate and endDate are already available from earlier in the function:
-            // const startDate = game.timelineStartParsed, endDate = game.timelineEndParsed;
-
-            if (game.englishTitle === "Trails in the Sky the 3rd" &&
-                startDate.year === endDate.year &&
-                startDate.month === endDate.month &&
-                !startDate.day && !endDate.day) {
-                durationStr = formatDisplayDate(startDate, game); // Show single month/year, e.g., "August S1203"
+            if (game.englishTitle === "Trails in the Sky the 3rd") {
+                // For "Trails in the Sky the 3rd", display only its single month/year.
+                // formatDisplayDate will correctly format this as "Month SYYYY".
+                // This assumes its timelineStartParsed accurately represents this single period.
+                durationStr = formatDisplayDate(game.timelineStartParsed, game);
             } else {
-                durationStr = `${formatDisplayDate(startDate, game)} - ${formatDisplayDate(endDate, game)}`;
+                // For all other games, display the range.
+                durationStr = `${formatDisplayDate(game.timelineStartParsed, game)} - ${formatDisplayDate(game.timelineEndParsed, game)}`;
             }
 
             const isSpecialGame = gameEntryDiv.classList.contains('special-info-below');


### PR DESCRIPTION
This commit consolidates several refinements to the date display logic in the lore timeline, ensuring accuracy and addressing specific formatting requests:

1.  **'Trails in the Sky the 3rd' Date Display**: Correctly displays as a single month and year (e.g., 'December S1203'), reflecting its occurrence within one calendar month without specific day events, based on `games.json` data.

2.  **Comma Removal for Month/Year Dates**: Dates consisting only of a month and year (e.g., 'January S1202') are now formatted without a comma between the month and the S-year (e.g., 'January S1202'). Dates including a day (e.g., 'November 29th, S1204') retain their existing comma and ordinal formatting.

3.  **Special Entry Text Styling**: For designated games ('Sky 3rd', 'CSIV', 'Reverie'), their title and dates are positioned below their timeline boxes with white text and drop shadow for readability. This includes fixes for ensuring dates are always visible and text wrapping is handled appropriately.

These changes were made through modifications to `lore-script.js` (for date logic and element creation) and `style.css` (for positioning and styling of special entries).