### PR TITLE
Move Acknowledgements section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This website provides a visual guide to the Trails series of video games, using 
 
 **Visit the live site: [https://jun-eau.github.io/trails-visual-guide/](https://jun-eau.github.io/trails-visual-guide/)**
 
+## Acknowledgements
+
+This project was heavily inspired by and uses some information from [trailsinthedatabase.com](https://trailsinthedatabase.com/).
+
 ## Disclaimer
 
 This project is not affiliated with Nihon Falcom, NIS America, XSEED, or GungHo.  

--- a/games.html
+++ b/games.html
@@ -33,6 +33,7 @@
             Unofficial fan project. Not affiliated with Falcom, NIS America, XSEED, or GungHo.<br>
             All visual assets © Nihon Falcom Corporation / NIS America, Inc. / XSEED Games / GungHo Online Entertainment, Inc.<br>
             Steam, PlayStation, Nintendo Switch, Wikipedia, and Kiseki Wiki (Fandom) logos are trademarks of their respective owners.<br>
+            This project was heavily inspired by and uses some information from <a href="https://trailsinthedatabase.com/">trailsinthedatabase.com</a>.<br>
             <a href="https://github.com/jun-eau/trails-visual-guide/">View the Source Code on GitHub</a>
         </p>
     </footer>

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
             Unofficial fan project. Not affiliated with Falcom, NIS America, XSEED, or GungHo.<br>
             All visual assets © Nihon Falcom Corporation / NIS America, Inc. / XSEED Games / GungHo Online Entertainment, Inc.<br>
             Steam, PlayStation, Nintendo Switch, Wikipedia, and Kiseki Wiki (Fandom) logos are trademarks of their respective owners.<br>
+            This project was heavily inspired by and uses some information from <a href="https://trailsinthedatabase.com/">trailsinthedatabase.com</a>.<br>
             <a href="https://github.com/jun-eau/trails-visual-guide/">View the Source Code on GitHub</a>
         </p>
     </footer>

--- a/lore.html
+++ b/lore.html
@@ -64,6 +64,7 @@
             Unofficial fan project. Not affiliated with Falcom, NIS America, XSEED, or GungHo.<br>
             All visual assets © Nihon Falcom Corporation / NIS America, Inc. / XSEED Games / GungHo Online Entertainment, Inc.<br>
             Steam, PlayStation, Nintendo Switch, Wikipedia, and Kiseki Wiki (Fandom) logos are trademarks of their respective owners.<br>
+            This project was heavily inspired by and uses some information from <a href="https://trailsinthedatabase.com/">trailsinthedatabase.com</a>.<br>
             <a href="https://github.com/jun-eau/trails-visual-guide/">View the Source Code on GitHub</a>
         </p>
     </footer>


### PR DESCRIPTION
The Acknowledgements section was moved to be between the introductory section and the Disclaimer section for better flow.