### PR TITLE
Fix: Adjust timeline column flex properties for better width scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -363,7 +363,7 @@ main {
 
 
 .timeline-arc-column {
-    flex: 1 1 0px; /* Equal width columns */
+    flex: 1 1 auto; /* Grow and shrink, starting from content's auto/intrinsic width */
     padding: 0 15px;
     border-right: 1px dashed rgba(153, 153, 185, 0.3);
     box-sizing: border-box;


### PR DESCRIPTION
Changed the `flex` property for `.timeline-arc-column` from `1 1 0px` to `1 1 auto`. This allows the columns to initially size based on their content (e.g., titles) before distributing remaining space. This should help them achieve a more reasonable width after the removal of the color key, which might have inadvertently influenced layout calculations.