### PR TITLE
Fix: Correct drop shadow clipping and update color

### DIFF
--- a/games.json
+++ b/games.json
@@ -56,7 +56,7 @@
         "nintendoUrl": null,
         "timelineStart": "1202-09-01",
         "timelineEnd": "1203-04-30",
-        "timelineColor": "#FBD15B",
+        "timelineColor": "#F2C663",
         "releasesJP": [
             { "date": "March 9, 2006", "platforms": "(PC)" },
             { "date": "December 27, 2007", "platforms": "(PSP)" },

--- a/style.css
+++ b/style.css
@@ -221,11 +221,11 @@ main {
     /* This container should not have overflow:hidden if arrows are outside its visual box */
     /* It should naturally take up the width of its content (the .game-entry-slider) */
     /* min-width from here is removed as it's now handled by 'main' element */
-    padding-bottom: 20px; /* Added padding to prevent shadow clipping */
 }
 
 .game-entry-slider {
-    overflow: hidden; /* Crucial for hiding other slides */
+    overflow-x: hidden;  /* This continues to hide the other slides horizontally */
+    overflow-y: visible; /* This allows the vertical box-shadow to be displayed */
     position: relative; /* Optional: if it needs to be a positioning context for something else inside, though not strictly necessary for current setup */
     /* width: 100%; Ensure it takes the space of a normal game-entry.
        This might already be handled by its container or flex properties.


### PR DESCRIPTION
- Reverted incorrect drop shadow fix by removing padding from .slider-display-area.
- Correctly fixed drop shadow clipping by setting overflow-x: hidden and overflow-y: visible on .game-entry-slider in style.css.
- Updated timelineColor for 'Trails in the Sky SC' in games.json to #F2C663.