### PR TITLE
Fix: Resolve clipped drop shadow on slider items

### DIFF
--- a/style.css
+++ b/style.css
@@ -221,6 +221,7 @@ main {
     /* This container should not have overflow:hidden if arrows are outside its visual box */
     /* It should naturally take up the width of its content (the .game-entry-slider) */
     /* min-width from here is removed as it's now handled by 'main' element */
+    padding-bottom: 20px; /* Create space for the box-shadow of items within */
 }
 
 .game-entry-slider {


### PR DESCRIPTION
Ensured proper visibility for box-shadows on game entries within sliders by:
1. Setting `overflow-x: hidden` and `overflow-y: visible` on `.game-entry-slider` to allow vertical overflow while hiding horizontal.
2. Setting `overflow: visible` on `.slider-item` to allow its children's shadows (from .art-container and .info-container) to render outside its bounds.
3. Adding `padding-bottom: 20px` to `.slider-display-area`. This provides the necessary physical space at the bottom of the slider's main container for the shadow to be drawn into, which was the critical missing piece previously.