### PR TITLE
Fix: Adjust slider spacing after shadow fix

### DIFF
--- a/style.css
+++ b/style.css
@@ -221,7 +221,7 @@ main {
     /* This container should not have overflow:hidden if arrows are outside its visual box */
     /* It should naturally take up the width of its content (the .game-entry-slider) */
     /* min-width from here is removed as it's now handled by 'main' element */
-    padding-bottom: 20px; /* Create space for the box-shadow of items within */
+    margin-bottom: -20px; /* Compensate for .slider-item's padding-bottom */
 }
 
 .game-entry-slider {
@@ -246,6 +246,7 @@ main {
     flex: 0 0 100%; /* Each item takes the full width of the slider viewport */
     box-sizing: border-box;
     overflow: visible; /* Allow box-shadow from child .game-entry to show */
+    padding-bottom: 20px; /* Add space for the shadow to render */
     /* .game-entry styles will apply to the child div within .slider-item */
 }
 


### PR DESCRIPTION
This commit addresses the spacing issue introduced after fixing the drop shadow clipping on slider items.

Previously, `padding-bottom: 20px;` was added to `.slider-item` to ensure enough space for the box-shadow to render. This successfully fixed the shadow clipping.

However, this padding also increased the overall height of the slider component, leading to excessive vertical spacing between stacked slider groups (e.g., between 'Trails in the Sky' and 'Trails in the Sky SC').

This commit introduces `margin-bottom: -20px;` to the `.slider-display-area` rule. This negative margin compensates for the internal padding of the last visible `.slider-item`, effectively pulling subsequent content up and restoring the intended visual gap between slider groups, while retaining the fix for the shadow visibility.