### PR TITLE
Fix: Stabilize timeline layout and remove color key

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -4,7 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let minDate, maxDate;
 
     // --- DOM Elements ---
-    const colorKeyContainer = document.getElementById('game-color-key-container');
     const timeAxisContainer = document.getElementById('time-axis-container');
     const gameColumnsContainer = document.getElementById('game-columns-container');
     const liberlColumn = document.getElementById('liberl-arc-column').querySelector('.game-entries-area');
@@ -53,7 +52,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             renderTimeAxis();
-            renderColorKey();
             renderGameEntries();
 
         } catch (error) {
@@ -160,31 +158,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const totalTimelineHeight = yOffset;
         [timeAxisContainer, liberlColumn, crossbellColumn, ereboniaColumn, monthLinesOverlay].forEach(el => {
             if (el) el.style.height = `${totalTimelineHeight}px`;
-        });
-    }
-
-    function renderColorKey() {
-        if (!allGames || allGames.length === 0 || !colorKeyContainer) return;
-        colorKeyContainer.innerHTML = '';
-        const uniqueGamesForKey = [], titlesForKey = new Set();
-        allGames.forEach(game => {
-            if (!titlesForKey.has(game.englishTitle)) {
-                uniqueGamesForKey.push({ title: game.englishTitle, color: game.timelineColor });
-                titlesForKey.add(game.englishTitle);
-            }
-        });
-        uniqueGamesForKey.sort((a, b) => a.title.localeCompare(b.title));
-        uniqueGamesForKey.forEach(item => {
-            const keyItemDiv = document.createElement('div');
-            keyItemDiv.classList.add('color-key-item');
-            const swatchDiv = document.createElement('div');
-            swatchDiv.classList.add('color-key-swatch');
-            swatchDiv.style.backgroundColor = item.color;
-            const titleSpan = document.createElement('span');
-            titleSpan.textContent = item.title;
-            keyItemDiv.appendChild(swatchDiv);
-            keyItemDiv.appendChild(titleSpan);
-            colorKeyContainer.appendChild(keyItemDiv);
         });
     }
 

--- a/lore.html
+++ b/lore.html
@@ -26,10 +26,6 @@
         <div class="timeline-section">
             <h2>Lore Timeline</h2>
 
-            <div id="game-color-key-container">
-                <!-- Color key will be populated by JavaScript -->
-            </div>
-
             <div id="lore-timeline-main-container">
                 <div id="time-axis-container">
                     <!-- Time axis labels (years, months) will be populated by JavaScript -->

--- a/style.css
+++ b/style.css
@@ -304,6 +304,7 @@ main {
 /* --- Lore Timeline Specific Styles --- */
 .timeline-section {
     margin-top: 1rem;
+    overflow-x: auto;
 }
 
 .timeline-section h2 { /* Style for "Lore Timeline" title */
@@ -314,34 +315,10 @@ main {
     margin-bottom: 1.5rem;
 }
 
-#game-color-key-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px 20px;
-    padding: 10px;
-    margin-bottom: 2rem;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 8px;
-}
-
-.color-key-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--font-size-sm);
-}
-
-.color-key-swatch {
-    width: 20px;
-    height: 20px;
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    border-radius: 4px;
-}
-
 #lore-timeline-main-container {
     display: flex;
     position: relative; /* For absolute positioning of month lines container */
+    width: 1200px;
 }
 
 #time-axis-container {


### PR DESCRIPTION
- Set a fixed width of 1200px for the lore timeline's main container.
- Enabled horizontal scrolling for the timeline section.
- Removed the color key HTML element from lore.html.
- Removed JavaScript functions and references related to the color key from lore-script.js.
- Deleted CSS rules for the color key from style.css.