### PR TITLE
Refactor: Improve timeline horizontal scrolling

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -26,30 +26,32 @@
         <div class="timeline-section">
             <h2>Lore Timeline</h2>
 
-            <div id="lore-timeline-main-container">
-                <div id="time-axis-container">
-                    <!-- Time axis labels (years, months) will be populated by JavaScript -->
-                </div>
-                <div id="game-columns-container">
-                    <div class="timeline-arc-column" id="liberl-arc-column">
-                        <h3>Liberl Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Liberl Arc game entries will be populated by JavaScript -->
-                        </div>
+            <div id="timeline-scroll-wrapper">
+                <div id="lore-timeline-main-container">
+                    <div id="time-axis-container">
+                        <!-- Time axis labels (years, months) will be populated by JavaScript -->
                     </div>
-                    <div class="timeline-arc-column" id="crossbell-arc-column">
-                        <h3>Crossbell Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Crossbell Arc game entries will be populated by JavaScript -->
+                    <div id="game-columns-container">
+                        <div class="timeline-arc-column" id="liberl-arc-column">
+                            <h3>Liberl Arc</h3>
+                            <div class="game-entries-area">
+                                <!-- Liberl Arc game entries will be populated by JavaScript -->
+                            </div>
                         </div>
-                    </div>
-                    <div class="timeline-arc-column" id="erebonia-arc-column">
-                        <h3>Erebonia Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Erebonia Arc game entries will be populated by JavaScript -->
+                        <div class="timeline-arc-column" id="crossbell-arc-column">
+                            <h3>Crossbell Arc</h3>
+                            <div class="game-entries-area">
+                                <!-- Crossbell Arc game entries will be populated by JavaScript -->
+                            </div>
                         </div>
+                        <div class="timeline-arc-column" id="erebonia-arc-column">
+                            <h3>Erebonia Arc</h3>
+                            <div class="game-entries-area">
+                                <!-- Erebonia Arc game entries will be populated by JavaScript -->
+                            </div>
+                        </div>
+                        <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                     </div>
-                    <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -304,7 +304,12 @@ main {
 /* --- Lore Timeline Specific Styles --- */
 .timeline-section {
     margin-top: 1rem;
+    /* overflow-x: auto; /* Removed from here */
+}
+
+#timeline-scroll-wrapper {
     overflow-x: auto;
+    width: 100%; /* Ensure it takes the available width of .timeline-section */
 }
 
 .timeline-section h2 { /* Style for "Lore Timeline" title */


### PR DESCRIPTION
- Wrapped #lore-timeline-main-container in a new #timeline-scroll-wrapper div.
- Moved overflow-x: auto from .timeline-section to #timeline-scroll-wrapper.
- This confines horizontal scrolling to the timeline component, preventing interference with main page scroll and sticky header.