### PR TITLE
Fix: Properly remove overflow from .timeline-section for correct scro…

### DIFF
--- a/style.css
+++ b/style.css
@@ -304,7 +304,6 @@ main {
 /* --- Lore Timeline Specific Styles --- */
 .timeline-section {
     margin-top: 1rem;
-    /* overflow-x: auto; /* Removed from here */
 }
 
 #timeline-scroll-wrapper {


### PR DESCRIPTION
…ll behavior

Ensured that `overflow-x: auto;` is completely removed from the `.timeline-section` selector in style.css. This corrects the previous oversight where the line was only commented out, ensuring that the horizontal scrolling is now correctly handled by the dedicated `#timeline-scroll-wrapper`.