### PR TITLE
Fix: Ensure timeline boxes display exact height

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,6 +1,42 @@
 [
     {
         "arc": "Liberl Arc",
+        "englishTitle": "Test: Single Day",
+        "japaneseTitleKanji": "テスト一日",
+        "japaneseTitleRomaji": "Test Ichinichi",
+        "assetName": "test-single-day",
+        "timelineStart": "1201-05-15",
+        "timelineEnd": "1201-05-15",
+        "timelineColor": "#FF00FF",
+        "releasesJP": [],
+        "releasesEN": []
+    },
+    {
+        "arc": "Liberl Arc",
+        "englishTitle": "Test: Few Days",
+        "japaneseTitleKanji": "テスト数日",
+        "japaneseTitleRomaji": "Test Suujitsu",
+        "assetName": "test-few-days",
+        "timelineStart": "1201-06-10",
+        "timelineEnd": "1201-06-13",
+        "timelineColor": "#FF00FF",
+        "releasesJP": [],
+        "releasesEN": []
+    },
+    {
+        "arc": "Liberl Arc",
+        "englishTitle": "Test: One Week",
+        "japaneseTitleKanji": "テスト一週間",
+        "japaneseTitleRomaji": "Test Isshuukan",
+        "assetName": "test-one-week",
+        "timelineStart": "1201-07-01",
+        "timelineEnd": "1201-07-07",
+        "timelineColor": "#FF00FF",
+        "releasesJP": [],
+        "releasesEN": []
+    },
+    {
+        "arc": "Liberl Arc",
         "englishTitle": "Trails in the Sky",
         "japaneseTitleKanji": "英雄伝説 空の軌跡FC",
         "japaneseTitleRomaji": "Sora no Kiseki FC",

--- a/lore-script.js
+++ b/lore-script.js
@@ -279,6 +279,11 @@ document.addEventListener('DOMContentLoaded', () => {
             // Ensure height is at least a small visible amount if it's very short, e.g. 1-day event
             // entryHeight = Math.max(entryHeight, pixelsPerMonthVertical * 0.1); // Min height of 10% of a month row
 
+            // Ensure that any positive calculated height is at least 1px.
+            if (entryHeight > 0 && entryHeight < 1) {
+                entryHeight = 1;
+            }
+
             if (entryHeight <= 0) { // topPosition can be negative if it starts before timeline minDate (padded)
                 console.warn(`Invalid height for ${game.englishTitle}. Calculated Height: ${entryHeight}. Skipping.`);
                 return;

--- a/style.css
+++ b/style.css
@@ -397,9 +397,9 @@ main {
 .game-entry-box {
     position: absolute;
     box-sizing: border-box;
-    border-radius: 6px;
-    padding: 8px 12px;
-    overflow: hidden;
+    border-radius: 2px; /* Tighter corners */
+    padding: 0; /* Remove padding to ensure height is exact */
+    overflow: hidden; /* Clip content for very short boxes */
     box-shadow: 0 2px 5px rgba(0,0,0,0.3);
     border: 1px solid rgba(255,255,255,0.3); /* Subtle border for better definition */
     color: var(--text-primary); /* Default text color, JS might override */
@@ -408,14 +408,12 @@ main {
     justify-content: center; /* Center content vertically if space allows */
     align-items: center; /* Center content horizontally */
     text-align: center;
-    /* overflow: hidden; is the default here, which is good for standard boxes */
 }
 
 /* Styles for special game entries where info is displayed below the box */
 .game-entry-box.special-info-below {
     overflow: visible !important; /* Crucial: allow text to appear outside the box boundaries */
-    /* Reset padding as text is no longer inside affecting this */
-    padding: 0;
+    /* Padding is already 0 from the rule above, so no change needed here for that */
     /* The flex properties for centering text inside are not needed here as text is absolute */
 }
 


### PR DESCRIPTION
Modified CSS and JavaScript for the Lore Timeline to ensure that game entry boxes always display their calculated height precisely.

Changes include:
- Removed padding from .game-entry-box.
- Reduced border-radius for .game-entry-box for tighter corners.
- Adjusted JavaScript to ensure that any calculated positive height less than 1px is rendered as 1px.
- Verified that text visibility logic for short boxes remains appropriate.
- Added test data to games.json to cover scenarios like single-day (1px), few-day, and week-long entries.

This allows for more accurate visual representation of event durations, including very short (e.g., 1-day) events.