### PR TITLE
Fix: Ensure timeline boxes display exact height and revert test data

### DIFF
--- a/games.json
+++ b/games.json
@@ -1,42 +1,6 @@
 [
     {
         "arc": "Liberl Arc",
-        "englishTitle": "Test: Single Day",
-        "japaneseTitleKanji": "テスト一日",
-        "japaneseTitleRomaji": "Test Ichinichi",
-        "assetName": "test-single-day",
-        "timelineStart": "1201-05-15",
-        "timelineEnd": "1201-05-15",
-        "timelineColor": "#FF00FF",
-        "releasesJP": [],
-        "releasesEN": []
-    },
-    {
-        "arc": "Liberl Arc",
-        "englishTitle": "Test: Few Days",
-        "japaneseTitleKanji": "テスト数日",
-        "japaneseTitleRomaji": "Test Suujitsu",
-        "assetName": "test-few-days",
-        "timelineStart": "1201-06-10",
-        "timelineEnd": "1201-06-13",
-        "timelineColor": "#FF00FF",
-        "releasesJP": [],
-        "releasesEN": []
-    },
-    {
-        "arc": "Liberl Arc",
-        "englishTitle": "Test: One Week",
-        "japaneseTitleKanji": "テスト一週間",
-        "japaneseTitleRomaji": "Test Isshuukan",
-        "assetName": "test-one-week",
-        "timelineStart": "1201-07-01",
-        "timelineEnd": "1201-07-07",
-        "timelineColor": "#FF00FF",
-        "releasesJP": [],
-        "releasesEN": []
-    },
-    {
-        "arc": "Liberl Arc",
         "englishTitle": "Trails in the Sky",
         "japaneseTitleKanji": "英雄伝説 空の軌跡FC",
         "japaneseTitleRomaji": "Sora no Kiseki FC",


### PR DESCRIPTION
This commit finalizes the changes for ensuring timeline game entry boxes display their calculated height precisely and reverts the games.json file to its original state, removing temporary test data.

Modifications include:
- CSS changes to .game-entry-box:
    - Removed padding to allow height to be exact.
    - Reduced border-radius for tighter corners.
- JavaScript changes in lore-script.js:
    - Ensured that any calculated positive height less than 1px is rendered as a 1px minimum.
    - Verified text visibility logic for short boxes.
- Reverted games.json to its state prior to test data addition.

The timeline now accurately reflects event durations, especially for short events, without visual inflation from padding.