### PR TITLE
Add informational note to Lore Timeline

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -26,6 +26,10 @@
         <div class="timeline-section">
             <h2>Lore Timeline</h2>
 
+            <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">
+                The timeline presented below is based on information sourced from in-game scripts and the <a href="https://kiseki.fandom.com/wiki/Timeline_of_Zemurian_history" target="_blank" rel="noopener noreferrer">Kiseki Wiki</a>.
+            </p>
+
             <div id="lore-timeline-main-container">
                 <div id="time-axis-container">
                     <!-- Time axis labels (years, months) will be populated by JavaScript -->


### PR DESCRIPTION
This commit adds a small note above the Lore Timeline in lore.html, indicating that the timeline is based on information from in-game scripts and the Kiseki Wiki. The note includes a hyperlink to the Kiseki Wiki's timeline page.