### PR TITLE
Refactor: Update timeline for multi-period games

### DIFF
--- a/games.json
+++ b/games.json
@@ -10,9 +10,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky",
         "playstationUrl": null,
         "nintendoUrl": null,
-        "timelineStart": "1202-01-01",
-        "timelineEnd": "1202-08-31",
         "timelineColor": "#3a8ece",
+        "timelineDisplayString": "March - September S.1202",
+        "timelinePeriods": [{ "start": "1202-03-01", "end": "1202-09-30" }],
         "releasesJP": [
             { "date": "June 24, 2004", "platforms": "(PC)" },
             { "date": "June 28, 2006", "platforms": "(PSP)" },
@@ -54,9 +54,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_SC",
         "playstationUrl": null,
         "nintendoUrl": null,
-        "timelineStart": "1202-09-01",
-        "timelineEnd": "1203-04-30",
         "timelineColor": "#F2C663",
+        "timelineDisplayString": "December S.1202 - March 7, S.1203",
+        "timelinePeriods": [{ "start": "1202-12-01", "end": "1203-03-07" }],
         "releasesJP": [
             { "date": "March 9, 2006", "platforms": "(PC)" },
             { "date": "December 27, 2007", "platforms": "(PSP)" },
@@ -78,9 +78,12 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_in_the_Sky_the_3rd",
         "playstationUrl": null,
         "nintendoUrl": null,
-        "timelineStart": "1203-11-28",
-        "timelineEnd": "1203-11-30",
         "timelineColor": "#7d50a1",
+        "timelineDisplayString": "Late Oct & Late Nov S.1203",
+        "timelinePeriods": [
+            { "start": "1203-10-27", "end": "1203-10-27", "label": "Prologue" },
+            { "start": "1203-11-29", "end": "1203-11-29", "label": "Phantasma" }
+        ],
         "releasesJP": [
             { "date": "June 28, 2007", "platforms": "(PC)" },
             { "date": "July 24, 2008", "platforms": "(PSP)" },
@@ -102,9 +105,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_from_Zero",
         "playstationUrl": "https://store.playstation.com/en-us/concept/10003242",
         "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-from-zero-switch/",
-        "timelineStart": "1204-01-01",
-        "timelineEnd": "1204-05-31",
         "timelineColor": "#218FCA",
+        "timelineDisplayString": "January - May S.1204",
+        "timelinePeriods": [{ "start": "1204-01-01", "end": "1204-05-31" }],
         "releasesJP": [
             { "date": "September 30, 2010", "platforms": "(PSP)" },
             { "date": "October 18, 2012", "platforms": "(PS Vita)" },
@@ -125,9 +128,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_to_Azure",
         "playstationUrl": "https://store.playstation.com/en-us/concept/10003337",
         "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-to-azure-switch/",
-        "timelineStart": "1204-08-01",
-        "timelineEnd": "1204-12-31",
         "timelineColor": "#0097aa",
+        "timelineDisplayString": "August 17 - December 30, S.1204",
+        "timelinePeriods": [{ "start": "1204-08-17", "end": "1204-12-30" }],
         "releasesJP": [
             { "date": "September 29, 2011", "platforms": "(PSP)" },
             { "date": "June 12, 2014", "platforms": "(PS Vita)" },
@@ -148,9 +151,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel",
         "playstationUrl": "https://store.playstation.com/en-us/concept/231981/",
         "nintendoUrl": null,
-        "timelineStart": "1204-03-01",
-        "timelineEnd": "1204-10-30",
         "timelineColor": "#ae2050",
+        "timelineDisplayString": "March 31 - October 30, S.1204",
+        "timelinePeriods": [{ "start": "1204-03-31", "end": "1204-10-30" }],
         "releasesJP": [
             { "date": "September 26, 2013", "platforms": "(PS3, PS Vita)" },
             { "date": "March 8, 2018", "platforms": "(PS4)" }
@@ -173,9 +176,12 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_II",
         "playstationUrl": "https://store.playstation.com/en-us/product/UP1023-CUSA12566_00-EDSENNOKISEKI2ND",
         "nintendoUrl": null,
-        "timelineStart": "1204-11-29",
-        "timelineEnd": "1205-03-13",
         "timelineColor": "#d61a28",
+        "timelineDisplayString": "Late Nov S.1204 - Mid March S.1205",
+        "timelinePeriods": [
+            { "start": "1204-11-29", "end": "1204-12-31", "label": "Main Story" },
+            { "start": "1205-03-13", "end": "1205-03-13", "label": "Epilogue" }
+        ],
         "releasesJP": [
             { "date": "September 25, 2014", "platforms": "(PS3, PS Vita)" },
             { "date": "April 26, 2018", "platforms": "(PS4)" }
@@ -198,9 +204,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_III",
         "playstationUrl": "https://store.playstation.com/en-us/product/UP1063-CUSA15119_00-FULLGAME00000000",
         "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-of-cold-steel-iii-switch/",
-        "timelineStart": "1206-04-15",
-        "timelineEnd": "1206-07-18",
         "timelineColor": "#4b5966",
+        "timelineDisplayString": "April 15 - July 18, S.1206",
+        "timelinePeriods": [{ "start": "1206-04-15", "end": "1206-07-18" }],
         "releasesJP": [
             { "date": "September 28, 2017", "platforms": "(PS4)" }
         ],
@@ -221,9 +227,9 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_of_Cold_Steel_IV",
         "playstationUrl": "https://store.playstation.com/en-us/product/UP1063-CUSA19637_00-EDSENNOKISEKI4TH",
         "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-of-cold-steel-iv-switch/",
-        "timelineStart": "1206-08-02",
-        "timelineEnd": "1206-09-01",
         "timelineColor": "#641207",
+        "timelineDisplayString": "August 2 - September 1, S.1206",
+        "timelinePeriods": [{ "start": "1206-08-02", "end": "1206-09-01" }],
         "releasesJP": [
             { "date": "September 27, 2018", "platforms": "(PS4)" }
         ],
@@ -243,9 +249,12 @@
         "fandomUrl": "https://kiseki.fandom.com/wiki/The_Legend_of_Heroes:_Trails_into_Reverie",
         "playstationUrl": "https://store.playstation.com/en-us/concept/10003228",
         "nintendoUrl": "https://www.nintendo.com/us/store/products/the-legend-of-heroes-trails-into-reverie-switch/",
-        "timelineStart": "1207-02-14",
-        "timelineEnd": "1207-03-22",
         "timelineColor": "#DFF8FC",
+        "timelineDisplayString": "Mid Feb & Mid March S.1207",
+        "timelinePeriods": [
+            { "start": "1207-02-14", "end": "1207-02-14", "label": "Prologue" },
+            { "start": "1207-03-15", "end": "1207-03-22", "label": "Main Story" }
+        ],
         "releasesJP": [
             { "date": "August 27, 2020", "platforms": "(PS4)" },
             { "date": "August 26, 2021", "platforms": "(PC, Switch)" }


### PR DESCRIPTION
- Replaces timelineStart/End with timelinePeriods in games.json for relevant games.
- Introduces timelineDisplayString for custom date range display.
- Overhauls lore-script.js to render separate visual blocks for each time period.
- Implements specific text display logic:
  - Default: Title and date string in the first box.
  - Special (Sky 3rd, Reverie, CS4): Title and date string below all boxes, with period breakdown.
  - CSII: Title and date string in 'Main Story' box; 'Epilogue' is a blank blip.
- Uses data-game-title attribute for robust positioning of 'below-box' text.