### PR TITLE
feat: update timeline data structure and rendering

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -438,7 +438,17 @@ document.addEventListener('DOMContentLoaded', () => {
                     tooltipText += ` (${period.label})`;
                 }
                 // Use the new period.display string directly in the tooltip
-                tooltipText += `\n${period.display ? period.display : formatDisplayDate(startDate, game) + " - " + formatDisplayDate(endDate, game)}`;
+                // Simplified logic for clarity and to avoid potential parsing issues in complex template literal
+                let dateForTooltip;
+                if (period.display) {
+                    dateForTooltip = period.display;
+                } else {
+                    // Fallback if period.display is somehow not available (shouldn't happen with current games.json)
+                    const formattedStart = formatDisplayDate(startDate, game);
+                    const formattedEnd = formatDisplayDate(endDate, game);
+                    dateForTooltip = `${formattedStart} - ${formattedEnd}`;
+                }
+                tooltipText += `\n${dateForTooltip}`;
                 gameEntryDiv.setAttribute('title', tooltipText);
 
                 targetColumn.appendChild(gameEntryDiv);


### PR DESCRIPTION
- Add 'display' field to each timelinePeriod in games.json with standardized date strings.
- Remove 'timelineDisplayString' from game entries in games.json.
- Update lore-script.js to use 'period.display' for timeline date rendering.
- Ensure tooltips also use the new 'period.display' string.