### PR TITLE
Fix: Prevent timeline title and note from scrolling horizontally

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -30,9 +30,10 @@
                 The timeline presented below is based on information sourced from in-game scripts and the <a href="https://kiseki.fandom.com/wiki/Timeline_of_Zemurian_history" target="_blank" rel="noopener noreferrer">Kiseki Wiki</a>.
             </p>
 
-            <div id="lore-timeline-main-container">
-                <div id="time-axis-container">
-                    <!-- Time axis labels (years, months) will be populated by JavaScript -->
+            <div class="lore-timeline-scroll-wrapper">
+                <div id="lore-timeline-main-container">
+                    <div id="time-axis-container">
+                        <!-- Time axis labels (years, months) will be populated by JavaScript -->
                 </div>
                 <div id="game-columns-container">
                     <div class="timeline-arc-column" id="liberl-arc-column">
@@ -56,6 +57,7 @@
                     <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                 </div>
             </div>
+        </div>
         </div>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -304,7 +304,12 @@ main {
 /* --- Lore Timeline Specific Styles --- */
 .timeline-section {
     margin-top: 1rem;
+    /* overflow-x: auto; */ /* Moved to .lore-timeline-scroll-wrapper */
+}
+
+.lore-timeline-scroll-wrapper {
     overflow-x: auto;
+    width: 100%; /* Ensures the wrapper itself doesn't overflow the page layout if content is narrower */
 }
 
 .timeline-section h2 { /* Style for "Lore Timeline" title */


### PR DESCRIPTION
Separated the Lore Timeline title and the informational note from the main timeline content's horizontal scrolling container.

- Modified lore.html to introduce a new `div.lore-timeline-scroll-wrapper` around `#lore-timeline-main-container`.
- Updated style.css to move `overflow-x: auto` from `.timeline-section` to `.lore-timeline-scroll-wrapper`.

This ensures that the title and note remain fixed at the top of their section during horizontal scrolling of the timeline, while still allowing normal vertical page scrolling.