### PR TITLE
Fix: Reduce spacing in lore timeline game boxes

### DIFF
--- a/style.css
+++ b/style.css
@@ -408,14 +408,14 @@ main {
     position: absolute;
     box-sizing: border-box;
     border-radius: 2px; /* Tighter corners */
-    padding: 0; /* Remove padding to ensure height is exact */
+    padding: 2px 0; /* Add small top/bottom padding, L/R remains 0 */
     overflow: hidden; /* Clip content for very short boxes */
     box-shadow: 0 2px 5px rgba(0,0,0,0.3);
     border: 1px solid rgba(255,255,255,0.3); /* Subtle border for better definition */
     color: var(--text-primary); /* Default text color, JS might override */
     display: flex;
     flex-direction: column;
-    justify-content: center; /* Center content vertically if space allows */
+    justify-content: flex-start; /* Align content to the top */
     align-items: center; /* Center content horizontally */
     text-align: center;
 }
@@ -475,7 +475,7 @@ main {
     font-weight: bold;
     font-size: var(--font-size-sm);
     line-height: var(--line-height-tight);
-    margin-bottom: 4px;
+    margin-bottom: 1px; /* Reduced margin */
 }
 
 .game-entry-duration {


### PR DESCRIPTION
Reduces vertical spacing for text within game entry boxes on the lore timeline:
- Aligns text (title and date) to the top of the box with a small padding.
- Reduces margin between the game title and the date display.

This makes the presentation of information within these boxes more compact.