### PR TITLE
Refine text spacing for multi-period games on Lore Timeline

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -337,6 +337,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                     let textContent = "";
                     if (period.isMain) {
+                        periodTextContainer.classList.add('is-main-period-text');
                         const titleEl = document.createElement('div');
                         titleEl.className = 'game-entry-title';
                         titleEl.textContent = game.englishTitle;
@@ -355,7 +356,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     periodTextContainer.appendChild(periodDetailEl);
 
                     // Adjust spacing based on whether it's a main display or not
-                    const spacing = period.isMain ? 5 : 1; // 5px for main, 1px for others
+                    const spacing = period.isMain ? 2 : 1; // 2px for main (tightened), 1px for others
                     periodTextContainer.style.top = `${topPosition + entryHeight + spacing}px`;
 
                     targetColumn.appendChild(periodTextContainer); // Add text container to the column

--- a/style.css
+++ b/style.css
@@ -469,6 +469,11 @@ main {
     font-weight: 600; /* Slightly less bold than main title, but distinct */
 }
 
+/* Specific adjustments for the main period text block */
+.game-info-below-text-container.is-main-period-text .game-entry-title {
+    margin-bottom: 1px; /* Tighten space between title and date */
+}
+
 
 /* Ensure the default title/duration styles don't conflict when text is inside */
 .game-entry-title {


### PR DESCRIPTION
- Added `is-main-period-text` class to the main period's text container in `lore-script.js`.
- Adjusted JavaScript to reduce the top spacing for these main period text containers from 5px to 2px.
- Added CSS to reduce `margin-bottom` on the title within these containers from 3px to 1px.

This change tightens the vertical spacing for the main text block (title and date) of multi-period games, improving visual cohesion without affecting other timeline text.