### PR TITLE
Apply refined text spacing to Trails of Cold Steel IV

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -411,6 +411,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (game.englishTitle === "Trails of Cold Steel IV") {
                 const infoBelowContainer = document.createElement('div');
                 infoBelowContainer.className = 'game-info-below-text-container'; // Keep existing class for potential shared styles
+                infoBelowContainer.classList.add('is-main-period-text'); // Add class for spacing refinement
                 infoBelowContainer.style.color = '#FFFFFF'; // Default color
                 infoBelowContainer.style.textAlign = 'center';
 
@@ -449,7 +450,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     });
                     infoBelowContainer.style.position = 'absolute';
-                    infoBelowContainer.style.top = `${lowestBoxBottom + 5}px`; // 5px spacing
+                    infoBelowContainer.style.top = `${lowestBoxBottom + 2}px`; // Tightened spacing to 2px
                     infoBelowContainer.style.left = '5%';
                     infoBelowContainer.style.width = '90%';
                 } else {


### PR DESCRIPTION
- Added `is-main-period-text` class to the text container for Trails of Cold Steel IV in `lore-script.js`.
- Adjusted the JavaScript to reduce the top spacing for CSIV's text container from 5px to 2px.

This extends the previous spacing refinement to CSIV, ensuring its timeline text block also benefits from the tighter visual cohesion. The existing CSS for `.is-main-period-text .game-entry-title` handles the title's bottom margin.