### PR TITLE
Fix: Correct background image path in hero section

### DIFF
--- a/style.css
+++ b/style.css
@@ -95,7 +95,7 @@ footer { margin-top: 2rem; color: var(--text-secondary); font-size: var(--font-s
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    background-image: url('../assets/hero/home-bg.jpg');
+    background-image: url('assets/hero/home-bg.jpg');
     background-size: cover;
     background-position: center;
     padding: 2rem; /* Add some padding for content */


### PR DESCRIPTION
The background image URL in .hero-section was pointing to '../assets/hero/home-bg.jpg', which is incorrect as style.css is in the root directory.

This commit changes the path to 'assets/hero/home-bg.jpg' to correctly load the background image.