### PR TITLE
Style: Make hero background fill viewport height

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,7 +90,7 @@ footer { margin-top: 2rem; color: var(--text-secondary); font-size: var(--font-s
 /* --- Hero Section (Home Page) --- */
 .hero-section {
     position: relative; /* For pseudo-element overlay */
-    min-height: 75vh;
+    height: 100%;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
Changed .hero-section min-height from 75vh to height: 100%. This allows the hero section to fully utilize the available vertical space between the header and footer, making its background image more effectively fill the screen on various aspect ratios.