### PR TITLE
Add active class to current page navigation link

### DIFF
--- a/games.html
+++ b/games.html
@@ -17,7 +17,7 @@
         <h1>Trails Series Visual Guide</h1>
         <nav class="main-navigation">
             <a href="index.html">Home</a>
-            <a href="games.html">Releases</a>
+            <a href="games.html" class="active">Releases</a>
             <a href="lore.html">Lore</a>
         </nav>
     </header>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <header>
         <h1>Trails Series Visual Guide</h1>
         <nav class="main-navigation">
-            <a href="index.html">Home</a>
+            <a href="index.html" class="active">Home</a>
             <a href="games.html">Releases</a>
             <a href="lore.html">Lore</a>
         </nav>

--- a/lore.html
+++ b/lore.html
@@ -18,7 +18,7 @@
         <nav class="main-navigation">
             <a href="index.html">Home</a>
             <a href="games.html">Releases</a>
-            <a href="lore.html">Lore</a>
+            <a href="lore.html" class="active">Lore</a>
         </nav>
     </header>
 


### PR DESCRIPTION
Manually adds the 'active' class to the main navigation links (Home, Releases, Lore) on their respective pages to ensure the current page is highlighted in the sticky header.

This provides a direct way to highlight the active link, complementing the existing JavaScript logic.